### PR TITLE
Expand 1D radial array to voxelized 3D spherical shells.

### DIFF
--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -513,7 +513,7 @@ class IterativeRefinement:
 
     @staticmethod
     def binary_mask_3d(center, radius, shape, fill=True, shell_thickness=1):
-        """Construct a binary spherical shell mask (variable thickness). 
+        """Construct a binary spherical shell mask (variable thickness).
 
         Parameters
         ----------
@@ -567,7 +567,9 @@ class IterativeRefinement:
         arr_3d = np.zeros((n_pix, n_pix, n_pix))
         center = (n_pix // 2, n_pix // 2, n_pix // 2)
         for i in reversed(range(n_pix // 2)):
-            mask = IterativeRefinement.binary_mask_3d(center, i, arr_3d.shape, fill=False)
+            mask = IterativeRefinement.binary_mask_3d(
+                center, i, arr_3d.shape, fill=False
+            )
             arr_3d = np.where(mask, arr_1d[i], arr_3d)
 
         return arr_3d

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -518,7 +518,6 @@ class IterativeRefinement:
         half_0 = np.flip(half_1, axis=2)
         arr_3d = np.concatenate((half_0, half_1), axis=2)
 
-        # arr_1d fsc_1d to 3d (spherical shells)
         return arr_3d
 
     @staticmethod

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -509,44 +509,6 @@ class IterativeRefinement:
         rho = u**2 + v**2 + w**2
 
         for i in reversed(range(half_pix)):
-            corner_111 = np.where(rho <= i**2, arr_1d[i], corner_111)
-
-        corner_011 = np.flip(corner_111, axis=0)
-        quarter_11 = np.concatenate((corner_011, corner_111), axis=0)
-        quarter_01 = np.flip(quarter_11, axis=1)
-        half_1 = np.concatenate((quarter_01, quarter_11), axis=1)
-        half_0 = np.flip(half_1, axis=2)
-        arr_3d = np.concatenate((half_0, half_1), axis=2)
-
-        # arr_1d fsc_1d to 3d (spherical shells)
-        return arr_3d
-
-    @staticmethod
-    def expand_1d_to_3d(arr_1d):
-        """Expand 1D array data into spherical shell.
-
-        Parameters
-        ----------
-        arr_1d : arr
-            Shape (n_pix // 2)
-
-        Returns
-        -------
-        arr_3d : arr
-            Shape (spherical coords)
-        """
-        half_pix = arr_1d.shape[0]
-        corner_111 = np.zeros((half_pix, half_pix, half_pix))
-
-        x = np.linspace(0, half_pix, half_pix)
-        y = np.linspace(0, half_pix, half_pix)
-        z = np.linspace(0, half_pix, half_pix)
-
-        u, v, w = np.meshgrid(x, y, z, indexing="ij")
-
-        rho = u**2 + v**2 + w**2
-
-        for i in reversed(range(half_pix)):
             corner_111 = np.where(rho <= (i + 1) ** 2, arr_1d[i], corner_111)
 
         corner_011 = np.flip(corner_111, axis=0)

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -512,7 +512,7 @@ class IterativeRefinement:
         return noise_estimates
 
     @staticmethod
-    def binary_mask_3d(center, radius, shape, shell=False, shell_thickness=1):
+    def binary_mask_3d(center, radius, shape, fill=True, shell_thickness=1):
         '''Construct a binary spherical shell mask (variable thickness). 
 
         Parameters
@@ -525,7 +525,7 @@ class IterativeRefinement:
         shape : array-like
             shape (3,)
             the shape of the outputted 3D array.
-        shell : bool
+        fill : bool
             Whether to output a shell or a solid sphere.
         shell_thickness : bool
             If outputting a shell, the shell thickness in pixels.
@@ -542,7 +542,7 @@ class IterativeRefinement:
         x0,x1,x2 = np.ogrid[-a:nx0-a,-b:nx1-b,-c:nx2-c]
         r2 = x0**2 + x1**2 + x2**2
         mask = r2 <= radius**2
-        if shell:
+        if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness)**2
             mask = np.logical_xor(mask_outer, mask_inner)
@@ -567,7 +567,7 @@ class IterativeRefinement:
         arr_3d = np.zeros((n_pix, n_pix, n_pix))
         center = (n_pix // 2, n_pix // 2, n_pix // 2)
         for i in reversed(range(n_pix // 2)):
-            mask = IterativeRefinement.binary_mask_3d(center, i, arr_3d.shape, shell=True)
+            mask = IterativeRefinement.binary_mask_3d(center, i, arr_3d.shape, fill=False)
             arr_3d = np.where(mask, arr_1d[i], arr_3d)
 
         return arr_3d

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -521,6 +521,7 @@ class IterativeRefinement:
         # arr_1d fsc_1d to 3d (spherical shells)
         return arr_3d
 
+    @staticmethod
     def expand_1d_to_3d(arr_1d):
         """Expand 1D array data into spherical shell.
 

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -500,9 +500,9 @@ class IterativeRefinement:
         half_pix = arr_1d.shape[0]
         corner_111 = np.zeros((half_pix, half_pix, half_pix))
 
-        x = np.linspace(0, half_pix, half_pix)
-        y = np.linspace(0, half_pix, half_pix)
-        z = np.linspace(0, half_pix, half_pix)
+        x = np.arange(0, half_pix)
+        y = np.arange(0, half_pix)
+        z = np.arange(0, half_pix)
 
         u, v, w = np.meshgrid(x, y, z, indexing="ij")
 

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -499,25 +499,25 @@ class IterativeRefinement:
         """
         half_pix = arr_1d.shape[0]
         corner_111 = np.zeros((half_pix, half_pix, half_pix))
-        
+
         x = np.linspace(0, half_pix, half_pix)
         y = np.linspace(0, half_pix, half_pix)
         z = np.linspace(0, half_pix, half_pix)
-        
-        u, v, w = np.meshgrid(x, y, z, indexing='ij')
-        
+
+        u, v, w = np.meshgrid(x, y, z, indexing="ij")
+
         rho = u**2 + v**2 + w**2
-        
+
         for i in reversed(range(half_pix)):
             corner_111 = np.where(rho <= i**2, arr_1d[i], corner_111)
-        
+
         corner_011 = np.flip(corner_111, axis=0)
         quarter_11 = np.concatenate((corner_011, corner_111), axis=0)
         quarter_01 = np.flip(quarter_11, axis=1)
         half_1 = np.concatenate((quarter_01, quarter_11), axis=1)
         half_0 = np.flip(half_1, axis=2)
         arr_3d = np.concatenate((half_0, half_1), axis=2)
-        
+
         # arr_1d fsc_1d to 3d (spherical shells)
         return arr_3d
 
@@ -541,12 +541,12 @@ class IterativeRefinement:
         y = np.linspace(0, half_pix, half_pix)
         z = np.linspace(0, half_pix, half_pix)
 
-        u, v, w = np.meshgrid(x, y, z, indexing='ij')
+        u, v, w = np.meshgrid(x, y, z, indexing="ij")
 
         rho = u**2 + v**2 + w**2
 
         for i in reversed(range(half_pix)):
-            corner_111 = np.where(rho <= (i+1)**2, arr_1d[i], corner_111)
+            corner_111 = np.where(rho <= (i + 1) ** 2, arr_1d[i], corner_111)
 
         corner_011 = np.flip(corner_111, axis=0)
         quarter_11 = np.concatenate((corner_011, corner_111), axis=0)

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -513,7 +513,7 @@ class IterativeRefinement:
 
     @staticmethod
     def binary_mask_3d(center, radius, shape, shell=False, shell_thickness=1):
-        '''Construct a binary spherical shell mask (variable thickness). 
+        """Construct a binary spherical shell mask (variable thickness).
 
         Parameters
         ----------
@@ -521,7 +521,7 @@ class IterativeRefinement:
             shape (3,)
             the co-ordinates of the center of the shell.
         radius : float
-            the radius in pixels of the shell. 
+            the radius in pixels of the shell.
         shape : array-like
             shape (3,)
             the shape of the outputted 3D array.
@@ -536,17 +536,17 @@ class IterativeRefinement:
             shape == shape
             An array of bools with "True" where the sphere mask is
             present.
-        '''
+        """
         a, b, c = center
         nx0, nx1, nx2 = shape
-        x0,x1,x2 = np.ogrid[-a:nx0-a,-b:nx1-b,-c:nx2-c]
+        x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
         r2 = x0**2 + x1**2 + x2**2
         mask = r2 <= radius**2
         if shell:
             mask_outer = mask
-            mask_inner = r2 <= (radius - shell_thickness)**2
+            mask_inner = r2 <= (radius - shell_thickness) ** 2
             mask = np.logical_xor(mask_outer, mask_inner)
-        return(mask)
+        return mask
 
     @staticmethod
     def expand_1d_to_3d(arr_1d, n_pix):
@@ -567,7 +567,9 @@ class IterativeRefinement:
         arr_3d = np.zeros((n_pix, n_pix, n_pix))
         center = (n_pix // 2, n_pix // 2, n_pix // 2)
         for i in reversed(range(n_pix // 2)):
-            mask = IterativeRefinement.binary_mask_3d(center, i, arr_3d.shape, shell=True)
+            mask = IterativeRefinement.binary_mask_3d(
+                center, i, arr_3d.shape, shell=True
+            )
             arr_3d = np.where(mask, arr_1d[i], arr_3d)
 
         return arr_3d

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -497,8 +497,64 @@ class IterativeRefinement:
         arr_3d : arr
             Shape (spherical coords)
         """
-        n_pix = arr_1d.shape[0] * 2
-        arr_3d = np.ones((n_pix, n_pix, n_pix))
+        half_pix = arr_1d.shape[0]
+        corner_111 = np.zeros((half_pix, half_pix, half_pix))
+        
+        x = np.linspace(0, half_pix, half_pix)
+        y = np.linspace(0, half_pix, half_pix)
+        z = np.linspace(0, half_pix, half_pix)
+        
+        u, v, w = np.meshgrid(x, y, z, indexing='ij')
+        
+        rho = u**2 + v**2 + w**2
+        
+        for i in reversed(range(half_pix)):
+            corner_111 = np.where(rho <= i**2, arr_1d[i], corner_111)
+        
+        corner_011 = np.flip(corner_111, axis=0)
+        quarter_11 = np.concatenate((corner_011, corner_111), axis=0)
+        quarter_01 = np.flip(quarter_11, axis=1)
+        half_1 = np.concatenate((quarter_01, quarter_11), axis=1)
+        half_0 = np.flip(half_1, axis=2)
+        arr_3d = np.concatenate((half_0, half_1), axis=2)
+        
+        # arr_1d fsc_1d to 3d (spherical shells)
+        return arr_3d
+
+    def expand_1d_to_3d(arr_1d):
+        """Expand 1D array data into spherical shell.
+
+        Parameters
+        ----------
+        arr_1d : arr
+            Shape (n_pix // 2)
+
+        Returns
+        -------
+        arr_3d : arr
+            Shape (spherical coords)
+        """
+        half_pix = arr_1d.shape[0]
+        corner_111 = np.zeros((half_pix, half_pix, half_pix))
+
+        x = np.linspace(0, half_pix, half_pix)
+        y = np.linspace(0, half_pix, half_pix)
+        z = np.linspace(0, half_pix, half_pix)
+
+        u, v, w = np.meshgrid(x, y, z, indexing='ij')
+
+        rho = u**2 + v**2 + w**2
+
+        for i in reversed(range(half_pix)):
+            corner_111 = np.where(rho <= (i+1)**2, arr_1d[i], corner_111)
+
+        corner_011 = np.flip(corner_111, axis=0)
+        quarter_11 = np.concatenate((corner_011, corner_111), axis=0)
+        quarter_01 = np.flip(quarter_11, axis=1)
+        half_1 = np.concatenate((quarter_01, quarter_11), axis=1)
+        half_0 = np.flip(half_1, axis=2)
+        arr_3d = np.concatenate((half_0, half_1), axis=2)
+
         # arr_1d fsc_1d to 3d (spherical shells)
         return arr_3d
 

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -162,6 +162,9 @@ def test_expand_1d_to_3d(test_ir, n_pix):
     spherical = test_ir.expand_1d_to_3d(arr1d)
 
     assert spherical.shape == (n_pix, n_pix, n_pix)
+    assert np.allclose(arr_1d[:], arr_3d[n_pix // 2:, n_pix // 2, n_pix // 2])
+    assert np.allclose(arr_1d[:], arr_3d[n_pix // 2, n_pix // 2:, n_pix // 2])
+    assert np.allclose(arr_1d[:], arr_3d[n_pix // 2, n_pix // 2, n_pix // 2:])
 
 
 def test_iterative_refinement(test_ir, n_pix):

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -159,7 +159,7 @@ def test_compute_fsc(test_ir, n_pix):
 def test_expand_1d_to_3d(test_ir, n_pix):
     """Test expansion of 1D array into spherical shell."""
     arr_1d = np.ones(n_pix // 2)
-    arr_3d = test_ir.expand_1d_to_3d(arr_1d)
+    arr_3d = test_ir.expand_1d_to_3d(arr_1d, n_pix)
 
     assert arr_3d.shape == (n_pix, n_pix, n_pix)
     assert np.allclose(arr_1d[:], arr_3d[n_pix // 2 :, n_pix // 2, n_pix // 2])

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -162,9 +162,9 @@ def test_expand_1d_to_3d(test_ir, n_pix):
     spherical = test_ir.expand_1d_to_3d(arr1d)
 
     assert spherical.shape == (n_pix, n_pix, n_pix)
-    assert np.allclose(arr_1d[:], arr_3d[n_pix // 2:, n_pix // 2, n_pix // 2])
-    assert np.allclose(arr_1d[:], arr_3d[n_pix // 2, n_pix // 2:, n_pix // 2])
-    assert np.allclose(arr_1d[:], arr_3d[n_pix // 2, n_pix // 2, n_pix // 2:])
+    assert np.allclose(arr_1d[:], arr_3d[n_pix // 2 :, n_pix // 2, n_pix // 2])
+    assert np.allclose(arr_1d[:], arr_3d[n_pix // 2, n_pix // 2 :, n_pix // 2])
+    assert np.allclose(arr_1d[:], arr_3d[n_pix // 2, n_pix // 2, n_pix // 2 :])
 
 
 def test_iterative_refinement(test_ir, n_pix):

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -158,10 +158,10 @@ def test_compute_fsc(test_ir, n_pix):
 
 def test_expand_1d_to_3d(test_ir, n_pix):
     """Test expansion of 1D array into spherical shell."""
-    arr1d = np.ones(n_pix // 2)
-    spherical = test_ir.expand_1d_to_3d(arr1d)
+    arr_1d = np.ones(n_pix // 2)
+    arr_3d = test_ir.expand_1d_to_3d(arr_1d)
 
-    assert spherical.shape == (n_pix, n_pix, n_pix)
+    assert arr_3d.shape == (n_pix, n_pix, n_pix)
     assert np.allclose(arr_1d[:], arr_3d[n_pix // 2:, n_pix // 2, n_pix // 2])
     assert np.allclose(arr_1d[:], arr_3d[n_pix // 2, n_pix // 2:, n_pix // 2])
     assert np.allclose(arr_1d[:], arr_3d[n_pix // 2, n_pix // 2, n_pix // 2:])


### PR DESCRIPTION
See https://github.com/compSPI/reconstructSPI/issues/20.

Demonstration of functionality (central slice of sphere shown):
![demo](https://user-images.githubusercontent.com/18370798/160542311-9f59a25b-ef30-4f75-8c77-ee5d2dc81369.PNG)

Currently uses a very simple algorithm: It "layers" shells from outermost inward onto one eighth of the sphere, i.e.:
```
1 - -     - - -     - - -     1 - -
1 1 -  +  2 - -  +  - - -  =  2 1 -
1 1 1     2 2 -     3 - -     3 2 1
```
those eighths of the sphere are then tiled to form the full sphere. 

This is not the most efficient way to do this, but it prevents many pesky errors (e.g. holes due to rounding).