### PR TITLE
Uniform discritization of SO(3) via random rotation matrices

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - codecov
   - coverage
   - gemmi
-  - geomstats
   - numpy
   - numba
   - pillow>=8.2.0
@@ -16,4 +15,5 @@ dependencies:
   - pytorch
   - pip :
       - git+https://github.com/compSPI/simSPI.git
+      - geomstats
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - codecov
   - coverage
   - gemmi
+  - geomstats
   - numpy
   - numba
   - pillow>=8.2.0

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -275,9 +275,9 @@ class IterativeRefinement:
             Array describing rotations.
             Shape (n_rotations, 3, 3)
         """
-        geom = special_orthogonal(3, 'matrix')
+        geom = special_orthogonal(3, "matrix")
         rots = geom.random_uniform(n_rotations)
-        
+
         return rots
 
     @staticmethod

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -1,6 +1,5 @@
 """Iterative refinement with Bayesian expectation maximization."""
 
-import healpy as hp
 import numpy as np
 from simSPI.transfer import eval_ctf
 

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -1,8 +1,9 @@
 """Iterative refinement with Bayesian expectation maximization."""
 
 import numpy as np
-from simSPI.transfer import eval_ctf
+
 from geomstats.geometry import special_orthogonal
+from simSPI.transfer import eval_ctf
 
 
 class IterativeRefinement:

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -1,7 +1,6 @@
 """Iterative refinement with Bayesian expectation maximization."""
 
 import numpy as np
-
 from geomstats.geometry import special_orthogonal
 from simSPI.transfer import eval_ctf
 
@@ -205,7 +204,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts**2)
+        return map_3d * counts / (norm_const + counts ** 2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -360,7 +359,7 @@ class IterativeRefinement:
         map_3d_f = np.ones_like(map_3d_f)
         xyz_rotated = np.ones_like(xy_plane)
 
-        size = n_rotations * n_pix**2
+        size = n_rotations * n_pix ** 2
         slices = np.random.normal(size=size)
         slices = slices.reshape((n_rotations, n_pix, n_pix))
         return slices, xyz_rotated

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -282,21 +282,21 @@ class IterativeRefinement:
                 (
                     (np.cos(phi), -np.sin(phi), 0),
                     (np.sin(phi), np.cos(phi), 0),
-                    (0, 0, 1)
+                    (0, 0, 1),
                 )
             )
             theta_matrix = np.array(
                 (
                     (np.cos(theta), 0, np.sin(theta)),
                     (0, 1, 0),
-                    (-np.sin(theta), 0, np.cos(theta))
+                    (-np.sin(theta), 0, np.cos(theta)),
                 )
             )
             psi_matrix = np.array(
                 (
                     (1, 0, 0),
                     (0, np.cos(psi), -np.sin(psi)),
-                    (0, np.sin(psi), np.cos(psi))
+                    (0, np.sin(psi), np.cos(psi)),
                 )
             )
             rots[i] = phi_matrix @ theta_matrix @ psi_matrix

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from simSPI.transfer import eval_ctf
+from geomstats.geometry import special_orthogonal
 
 
 class IterativeRefinement:
@@ -274,31 +275,9 @@ class IterativeRefinement:
             Array describing rotations.
             Shape (n_rotations, 3, 3)
         """
-        rots = np.zeros((n_rotations, 3, 3))
-        for i in range(n_rotations):
-            phi, theta, psi = np.random.random(3) * 2 * np.pi
-            phi_matrix = np.array(
-                (
-                    (np.cos(phi), -np.sin(phi), 0),
-                    (np.sin(phi), np.cos(phi), 0),
-                    (0, 0, 1),
-                )
-            )
-            theta_matrix = np.array(
-                (
-                    (np.cos(theta), 0, np.sin(theta)),
-                    (0, 1, 0),
-                    (-np.sin(theta), 0, np.cos(theta)),
-                )
-            )
-            psi_matrix = np.array(
-                (
-                    (1, 0, 0),
-                    (0, np.cos(psi), -np.sin(psi)),
-                    (0, np.sin(psi), np.cos(psi)),
-                )
-            )
-            rots[i] = phi_matrix @ theta_matrix @ psi_matrix
+        geom = special_orthogonal(3, 'matrix')
+        rots = geom.random_uniform(n_rotations)
+        
         return rots
 
     @staticmethod

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -275,9 +275,10 @@ class IterativeRefinement:
             Array describing rotations.
             Shape (n_rotations, 3, 3)
         """
-        geom = special_orthogonal(3, "matrix")
+        geom = special_orthogonal.SpecialOrthogonal(3, "matrix")
         rots = geom.random_uniform(n_rotations)
-
+        negatives = np.tile(np.random.randint(2, size=n_rotations) * 2 - 1, (3, 3, 1)).T
+        rots[:] *= negatives
         return rots
 
     @staticmethod

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -281,6 +281,10 @@ class IterativeRefinement:
     def grid_SO3_uniform(n_rotations):
         """Generate uniformly distributed rotations in SO(3).
 
+        A note on functionality - the geomstats random_uniform library only produces
+        rotations onto one hemisphere. So, the rotations are randomly inverted, giving
+        them equal probability to fall in either hemisphere.
+
         Parameters
         ----------
         n_rotations : int

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -301,7 +301,7 @@ class IterativeRefinement:
                     [0, np.sin(theta), np.cos(theta)]
                 ]
             )
-            return np.dot(phi_matrices, theta_matrices)
+            return phi_matrices * theta_matrices
 
     @staticmethod
     def generate_xy_plane(n_pix):

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -275,33 +275,32 @@ class IterativeRefinement:
             Array describing rotations.
             Shape (n_rotations, 3, 3)
         """
-        try:
-            # If n_rotations fits the healpix rotations, 
-            # we can do a proper uniform map.
-            nside = hp.npix2nside(n_rotations)
-
-            rots = np.ones((n_rotations, 3, 3))
-            return rots
-        except ValueError:
-            # If n_rotations can't be evenly distributed
-            # on a sphere by healpix, use random rots.
-            phi = np.random.random(n_rotations) * 2 * np.pi()
-            theta = np.arccos(np.random.random(n_rotations)) * (np.random.randint(2) * 2 - 1)
-            phi_matrices = np.array(
-                [
-                    [np.cos(phi), -np.sin(phi), 0],
-                    [np.sin(phi), np.cos(phi), 0],
-                    [0, 0, 1]
-                ]
+        rots = np.zeros((n_rotations, 3, 3))
+        for i in range(n_rotations):
+            phi, theta, psi = np.random.random(3) * 2 * np.pi
+            phi_matrix = np.array(
+                (
+                    (np.cos(phi), -np.sin(phi), 0),
+                    (np.sin(phi), np.cos(phi), 0),
+                    (0, 0, 1)
+                )
             )
-            theta_matrices = np.array(
-                [
-                    [1, 0, 0],
-                    [0, np.cos(theta), -np.sin(theta)],
-                    [0, np.sin(theta), np.cos(theta)]
-                ]
+            theta_matrix = np.array(
+                (
+                    (np.cos(theta), 0, np.sin(theta)),
+                    (0, 1, 0),
+                    (-np.sin(theta), 0, np.cos(theta))
+                )
             )
-            return phi_matrices * theta_matrices
+            psi_matrix = np.array(
+                (
+                    (1, 0, 0),
+                    (0, np.cos(psi), -np.sin(psi)),
+                    (0, np.sin(psi), np.cos(psi))
+                )
+            )
+            rots[i] = phi_matrix @ theta_matrix @ psi_matrix
+        return rots
 
     @staticmethod
     def generate_xy_plane(n_pix):

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -204,7 +204,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts ** 2)
+        return map_3d * counts / (norm_const + counts**2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -359,7 +359,7 @@ class IterativeRefinement:
         map_3d_f = np.ones_like(map_3d_f)
         xyz_rotated = np.ones_like(xy_plane)
 
-        size = n_rotations * n_pix ** 2
+        size = n_rotations * n_pix**2
         slices = np.random.normal(size=size)
         slices = slices.reshape((n_rotations, n_pix, n_pix))
         return slices, xyz_rotated

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -90,7 +90,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (n_pix**2, 3)
+    assert xy_plane.shape == (n_pix ** 2, 3)
 
 
 def test_generate_slices(test_ir, n_particles, n_pix):
@@ -101,9 +101,9 @@ def test_generate_slices(test_ir, n_particles, n_pix):
 
     slices, xyz_rotated = test_ir.generate_slices(map_3d, xy_plane, n_pix, rots)
 
-    assert xy_plane.shape == (n_pix**2, 3)
+    assert xy_plane.shape == (n_pix ** 2, 3)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated.shape == (n_pix**2, 3)
+    assert xyz_rotated.shape == (n_pix ** 2, 3)
 
 
 def test_apply_ctf_to_slice(test_ir, n_pix):

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -90,7 +90,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (n_pix ** 2, 3)
+    assert xy_plane.shape == (n_pix**2, 3)
 
 
 def test_generate_slices(test_ir, n_particles, n_pix):
@@ -101,9 +101,9 @@ def test_generate_slices(test_ir, n_particles, n_pix):
 
     slices, xyz_rotated = test_ir.generate_slices(map_3d, xy_plane, n_pix, rots)
 
-    assert xy_plane.shape == (n_pix ** 2, 3)
+    assert xy_plane.shape == (n_pix**2, 3)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated.shape == (n_pix ** 2, 3)
+    assert xyz_rotated.shape == (n_pix**2, 3)
 
 
 def test_apply_ctf_to_slice(test_ir, n_pix):


### PR DESCRIPTION
See https://github.com/compSPI/reconstructSPI/issues/13. 

Gridding of SO(3) via randomly distributed rotations - a 3D rotation matrix is generated from geomstats.. 

Demonstration of functionality (in each image 1000 rotation matrices are applied to a cartesian axis unit vector and plotted). 
![demo2](https://user-images.githubusercontent.com/18370798/160774847-91d36429-1887-4791-849c-8b3af810c0ba.PNG)