### PR TITLE
rotate to keep dc component in correct location

### DIFF
--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -225,7 +225,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts ** 2)
+        return map_3d * counts / (norm_const + counts**2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -342,7 +342,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix ** 2))
+        xy_plane = np.zeros((3, n_pix**2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -411,7 +411,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, map_3d_f.shape[0], map_3d_f.shape[1]))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -477,7 +477,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma ** 2) ** -1)
+        scale = -((2 * sigma**2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -595,8 +595,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
-        mask = r2 <= radius ** 2
+        r2 = x0**2 + x1**2 + x2**2
+        mask = r2 <= radius**2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -225,7 +225,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts**2)
+        return map_3d * counts / (norm_const + counts ** 2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -342,7 +342,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix**2))
+        xy_plane = np.zeros((3, n_pix ** 2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -385,9 +385,9 @@ class IterativeRefinement:
         """
         n_rotations = rots.shape[0]
         slices = np.empty((n_rotations, map_3d_f.shape[0], map_3d_f.shape[1]))
-        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
         for i in range(n_rotations):
-            xyz_rotated[i] = rots[i] @ (xy_plane + 0.5) - 0.5
+            xyz_rotated[i] = rots[i] @ xy_plane
 
             slices[i] = map_coordinates(map_3d_f, xyz_rotated[i] + n_pix // 2).reshape(
                 (n_pix, n_pix)
@@ -451,7 +451,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma**2) ** -1)
+        scale = -((2 * sigma ** 2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -569,8 +569,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0**2 + x1**2 + x2**2
-        mask = r2 <= radius**2
+        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
+        mask = r2 <= radius ** 2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -225,7 +225,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts**2)
+        return map_3d * counts / (norm_const + counts ** 2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -342,7 +342,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix**2))
+        xy_plane = np.zeros((3, n_pix ** 2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -362,7 +362,7 @@ class IterativeRefinement:
 
         Parameters
         ----------
-        map_3d_f : arr
+        map_3d_f : arr, float (not complex)
             Shape (n_pix, n_pix, n_pix)
         xy_plane : arr
             Array describing xy plane in space.
@@ -382,10 +382,22 @@ class IterativeRefinement:
         xyz_rotated : arr
             Rotated xy planes.
             Shape (n_rotations, 3, n_pix**2)
+
+
+        Notes
+        -----
+        The coordinates are not centered, and the origin/dc component
+        is in map_coordinates. This results in an artefact where the
+        first column of slices[i] is not (always) interpolated,
+        because some rotations, like a 180 deg in xy-plane rotation,
+        do not reach it. It is related to the coordinates going
+        from [n_pix/2,n_pix/2-1] and not [n_pix/2,n_pix/2].
         """
         n_rotations = rots.shape[0]
         slices = np.empty((n_rotations, map_3d_f.shape[0], map_3d_f.shape[1]))
-        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
+        overwrite_empty_with_zero = 0
+        slices[:, :, 0] = overwrite_empty_with_zero
+        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -451,7 +463,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma**2) ** -1)
+        scale = -((2 * sigma ** 2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -569,8 +581,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0**2 + x1**2 + x2**2
-        mask = r2 <= radius**2
+        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
+        mask = r2 <= radius ** 2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -225,7 +225,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts**2)
+        return map_3d * counts / (norm_const + counts ** 2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -342,7 +342,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix**2))
+        xy_plane = np.zeros((3, n_pix ** 2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -409,18 +409,21 @@ class IterativeRefinement:
         Otherwise by a rotation, the overall scale of the projection changes,
         which is totally undesirable.
 
-        This makes the "edge effects" of having zeros on an edge after
-        the map_coordinates inevitable. So the tests are a bit awkward when checking
-        that all ones project to a plane of ones. However, one can just add in the
-        edge effect to match the return of generate_slices. In practice real slices
-        will go to zero at the edge, and include masking that crops
-        closer into the centre, keeping a safe distance from the edge.
+        This makes the "edge effects" of (possibly) having zeros in the values of
+        map_coordinates corresponding to -n/2 xyz coordinates after rotation,
+        i.e. map_coordinates[0,:,:], map_coordinates[:,0,:] and map_coordinates[:,:,0],
+        which correspond to slices[0,:], slices[:,0].
+        This behaviour should be anticipated.
+        In practice real slices will come from a map_3d_f that goes to zero at the edge,
+        and the slices will also go to zero at the edge.
+        As far as the presence of noise in the edge pixels, masking that crops
+        close enough to the centre will keeping a safe distance from the edge.
         """
         n_rotations = rots.shape[0]
         slices = np.empty((n_rotations, map_3d_f.shape[0], map_3d_f.shape[1]))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -486,7 +489,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma**2) ** -1)
+        scale = -((2 * sigma ** 2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -604,8 +607,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0**2 + x1**2 + x2**2
-        mask = r2 <= radius**2
+        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
+        mask = r2 <= radius ** 2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -225,7 +225,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts ** 2)
+        return map_3d * counts / (norm_const + counts**2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -342,7 +342,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix ** 2))
+        xy_plane = np.zeros((3, n_pix**2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -397,7 +397,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, map_3d_f.shape[0], map_3d_f.shape[1]))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -463,7 +463,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma ** 2) ** -1)
+        scale = -((2 * sigma**2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -581,8 +581,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
-        mask = r2 <= radius ** 2
+        r2 = x0**2 + x1**2 + x2**2
+        mask = r2 <= radius**2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -364,9 +364,18 @@ class IterativeRefinement:
         ----------
         map_3d_f : arr, float (not complex)
             Shape (n_pix, n_pix, n_pix)
+            Convention x,y,z, with
+                -n_pix/2,-n_pix/2,-n_pix/2 pixel at map_3d_f[0,0,0],
+                0,0,0 pixel at map_3d_f[n/2,n/2,n/2]
+                n_pix/2-1,n_pix/2-1,n_pix/2-1 pixel at the final corner,
+                    i.e. map_3d_f[n_pix-1,n_pix-1,n_pix-1]
         xy_plane : arr
             Array describing xy plane in space.
             Shape (3, n_pix**2)
+            Convention x,y,z, i.e.
+                xy_plane[0] is x coordinate
+                xy_plane[1] is y coordinate
+                xy_plane[2] is z coordinate, which is all zero
         n_pix : int
             Number of pixels along one edge of the plane.
         rots : arr

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -225,7 +225,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts ** 2)
+        return map_3d * counts / (norm_const + counts**2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -342,7 +342,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix ** 2))
+        xy_plane = np.zeros((3, n_pix**2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -385,7 +385,7 @@ class IterativeRefinement:
         """
         n_rotations = rots.shape[0]
         slices = np.empty((n_rotations, map_3d_f.shape[0], map_3d_f.shape[1]))
-        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -451,7 +451,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma ** 2) ** -1)
+        scale = -((2 * sigma**2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -569,8 +569,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
-        mask = r2 <= radius ** 2
+        r2 = x0**2 + x1**2 + x2**2
+        mask = r2 <= radius**2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -225,7 +225,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts ** 2)
+        return map_3d * counts / (norm_const + counts**2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -342,7 +342,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix ** 2))
+        xy_plane = np.zeros((3, n_pix**2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -423,7 +423,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, map_3d_f.shape[0], map_3d_f.shape[1]))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -489,7 +489,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma ** 2) ** -1)
+        scale = -((2 * sigma**2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -607,8 +607,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
-        mask = r2 <= radius ** 2
+        r2 = x0**2 + x1**2 + x2**2
+        mask = r2 <= radius**2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -90,7 +90,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix ** 2)
+    assert xy_plane.shape == (3, n_pix**2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -122,7 +122,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, n_pix, rots)
 
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
 
     map_plane_ones = np.zeros((n_pix, n_pix, n_pix))
     map_plane_ones[n_pix // 2] = np.ones((n_pix, n_pix))

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -9,7 +9,9 @@ from reconstructSPI.iterative_refinement import expectation_maximization as em
 @pytest.fixture
 def n_pix():
     """Get test pixel count for consistency."""
-    return np.random.randint(1, 11) * 2
+    n_pix_half_max = 8
+    n_pix_half_min = 2
+    return np.random.randint(n_pix_half_min, n_pix_half_max + 1) * 2
 
 
 @pytest.fixture
@@ -152,12 +154,19 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     expected_slice[:, n_pix // 2 - 1] = 1
 
     expected_slice[0, :] = map_coordinates_artefact
-    expected_slice[:, 0] = map_coordinates_artefact
+    # expected_slice[:, 0] = map_coordinates_artefact
 
     slices, xyz_rotated_planes = test_ir.generate_slices(
         map_plane_ones, xy_plane, n_pix, rot_180deg_about_z
     )
     assert np.allclose(slices[0], expected_slice)
+
+    map_3d_dc = np.zeros((n_pix, n_pix, n_pix))
+    map_3d_dc[n_pix // 2, n_pix // 2, n_pix // 2] = 1
+    slices, xyz_rotated_planes = test_ir.generate_slices(
+        map_plane_ones, xy_plane, n_pix, rot_90deg_about_y
+    )
+    assert np.allclose(slices[:, n_pix // 2, n_pix // 2], np.ones(len(slices)))
 
 
 def test_apply_ctf_to_slice(test_ir, n_pix):

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -92,7 +92,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix ** 2)
+    assert xy_plane.shape == (3, n_pix**2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -125,7 +125,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     xy_plane = test_ir.generate_xy_plane(n_pix)
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, n_pix, rots)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
 
     map_3d_dc = np.zeros((n_pix, n_pix, n_pix))
     rand_val = np.random.uniform(low=1, high=2)

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -92,7 +92,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix ** 2)
+    assert xy_plane.shape == (3, n_pix**2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -126,7 +126,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     xy_plane = test_ir.generate_xy_plane(n_pix)
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, n_pix, rots)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
 
     map_3d_dc = np.zeros((n_pix, n_pix, n_pix))
     rand_val = np.random.uniform(low=1, high=2)

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -92,7 +92,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix**2)
+    assert xy_plane.shape == (3, n_pix ** 2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -108,7 +108,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
 
     1. shape test.
 
-    2. dc component test. DC component should not change after any rotation.
+    2. DC (origin) component test. DC component should not change after any rotation.
 
     3. 90-degree rotation test.
     Map has ones in central xz-plane.
@@ -126,17 +126,17 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     xy_plane = test_ir.generate_xy_plane(n_pix)
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, n_pix, rots)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
 
     map_3d_dc = np.zeros((n_pix, n_pix, n_pix))
-    rand_val = np.random.random_uniform(low=1, high=2)
+    rand_val = np.random.uniform(low=1, high=2)
     map_3d_dc[n_pix // 2, n_pix // 2, n_pix // 2] = rand_val
+    expected_dc = rand_val * np.ones(len(slices))
     slices, xyz_rotated_planes = test_ir.generate_slices(
         map_3d_dc, xy_plane, n_pix, rots
     )
-    assert np.allclose(
-        slices[:, n_pix // 2, n_pix // 2], rand_val * np.ones(len(slices))
-    )
+    projected_dc = slices[:, n_pix // 2, n_pix // 2]
+    assert np.allclose(projected_dc, expected_dc)
 
     map_plane_ones = np.zeros((n_pix, n_pix, n_pix))
     map_plane_ones[n_pix // 2] = np.ones((n_pix, n_pix))

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -92,7 +92,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix ** 2)
+    assert xy_plane.shape == (3, n_pix**2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -130,7 +130,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     xy_plane = test_ir.generate_xy_plane(n_pix)
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, n_pix, rots)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
 
     map_3d_dc = np.zeros((n_pix, n_pix, n_pix))
     rand_val = np.random.uniform(low=1, high=2)

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -92,7 +92,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix ** 2)
+    assert xy_plane.shape == (3, n_pix**2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -122,7 +122,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     xy_plane = test_ir.generate_xy_plane(n_pix)
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, n_pix, rots)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
 
     map_plane_ones = np.zeros((n_pix, n_pix, n_pix))
     map_plane_ones[n_pix // 2] = np.ones((n_pix, n_pix))

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -92,7 +92,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix**2)
+    assert xy_plane.shape == (3, n_pix ** 2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -106,27 +106,26 @@ def test_generate_xy_plane(test_ir, n_pix):
 def test_generate_slices(test_ir, n_particles, n_pix):
     """Test generation of slices.
 
-    1. shape test.
+    1. Shape test.
 
     2. DC (origin) component test. DC component should not change after any rotation.
 
-    3. 90-degree rotation test.
+    3. 90-degree-rotation plane-to-line test.
     Map has ones in central xz-plane.
     Rotating by -90 degrees about y
-    should produce a line along the y direction.
+    should produce a slice with a line along the y direction at the central x coord.
 
-    4. 180-degree rotation test.
+    4. 180-degree-rotation plane-to-plane test.
     Map has ones in central xy-plane.
     Rotating by 180 degrees about z
-    should produce a similar matrix,
-    namely a slice of ones.
+    should produce a similar slice of ones.
     """
     map_3d = np.ones((n_pix, n_pix, n_pix))
     rots = test_ir.grid_SO3_uniform(n_particles)
     xy_plane = test_ir.generate_xy_plane(n_pix)
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, n_pix, rots)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
 
     map_3d_dc = np.zeros((n_pix, n_pix, n_pix))
     rand_val = np.random.uniform(low=1, high=2)

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -90,7 +90,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix**2)
+    assert xy_plane.shape == (3, n_pix ** 2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -122,7 +122,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, n_pix, rots)
 
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
 
     map_plane_ones = np.zeros((n_pix, n_pix, n_pix))
     map_plane_ones[n_pix // 2] = np.ones((n_pix, n_pix))
@@ -136,7 +136,11 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     slices, xyz_rotated_planes = test_ir.generate_slices(
         map_plane_ones, xy_plane, n_pix, rot_90deg_about_y
     )
-    assert np.allclose(slices[0], np.ones_like(slices[0]))
+    all_ones = np.ones_like(slices[0])
+    map_coordinates_artefact = 0
+    all_ones[0, :] = map_coordinates_artefact
+    all_ones[:, 0] = map_coordinates_artefact
+    assert np.allclose(slices[0], all_ones)
 
     rot_180deg_about_z = np.array(
         [
@@ -146,6 +150,9 @@ def test_generate_slices(test_ir, n_particles, n_pix):
 
     expected_slice = np.zeros((n_pix, n_pix))
     expected_slice[:, n_pix // 2 - 1] = 1
+
+    expected_slice[0, :] = map_coordinates_artefact
+    expected_slice[:, 0] = map_coordinates_artefact
 
     slices, xyz_rotated_planes = test_ir.generate_slices(
         map_plane_ones, xy_plane, n_pix, rot_180deg_about_z

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -149,12 +149,15 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     )
     expected_slice_line_y = np.zeros_like(slices[0])
     expected_slice_line_y[n_pix // 2] = 1
-    map_coordinates_artefact = 0
-    expected_slice_line_y[:, 0] = map_coordinates_artefact
+
     slices, xyz_rotated_planes = test_ir.generate_slices(
         map_plane_ones_xzplane, xy_plane, n_pix, rot_90deg_about_y
     )
-    assert np.allclose(slices[0], expected_slice_line_y)
+    omit_idx_artefact = 1
+    assert np.allclose(
+        slices[0, omit_idx_artefact:, omit_idx_artefact:],
+        expected_slice_line_y[omit_idx_artefact:, omit_idx_artefact:],
+    )
 
     rot_180deg_about_z = np.array(
         [
@@ -164,12 +167,13 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     map_plane_ones_xyplane = np.zeros((n_pix, n_pix, n_pix))
     map_plane_ones_xyplane[:, :, n_pix // 2] = 1
     expected_slice = np.ones((n_pix, n_pix))
-    expected_slice[0, :] = map_coordinates_artefact
-    expected_slice[:, 0] = map_coordinates_artefact
     slices, xyz_rotated_planes = test_ir.generate_slices(
         map_plane_ones_xyplane, xy_plane, n_pix, rot_180deg_about_z
     )
-    assert np.allclose(slices[0], expected_slice)
+    assert np.allclose(
+        slices[0, omit_idx_artefact:, omit_idx_artefact:],
+        expected_slice[omit_idx_artefact:, omit_idx_artefact:],
+    )
 
 
 def test_apply_ctf_to_slice(test_ir, n_pix):

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -92,7 +92,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix**2)
+    assert xy_plane.shape == (3, n_pix ** 2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -120,28 +120,23 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     map_3d = np.ones((n_pix, n_pix, n_pix))
     rots = test_ir.grid_SO3_uniform(n_particles)
     xy_plane = test_ir.generate_xy_plane(n_pix)
-
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, n_pix, rots)
-
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
 
     map_plane_ones = np.zeros((n_pix, n_pix, n_pix))
     map_plane_ones[n_pix // 2] = np.ones((n_pix, n_pix))
-
     rot_90deg_about_y = np.array(
         [
             [[0, 0, 1], [0, 1, 0], [-1, 0, 0]],
         ]
     )
-
-    slices, xyz_rotated_planes = test_ir.generate_slices(
-        map_plane_ones, xy_plane, n_pix, rot_90deg_about_y
-    )
     all_ones = np.ones_like(slices[0])
     map_coordinates_artefact = 0
     all_ones[0, :] = map_coordinates_artefact
-    all_ones[:, 0] = map_coordinates_artefact
+    slices, xyz_rotated_planes = test_ir.generate_slices(
+        map_plane_ones, xy_plane, n_pix, rot_90deg_about_y
+    )
     assert np.allclose(slices[0], all_ones)
 
     rot_180deg_about_z = np.array(
@@ -149,13 +144,9 @@ def test_generate_slices(test_ir, n_particles, n_pix):
             [[-1, 0, 0], [0, -1, 0], [0, 0, 1]],
         ]
     )
-
     expected_slice = np.zeros((n_pix, n_pix))
     expected_slice[:, n_pix // 2 - 1] = 1
-
     expected_slice[0, :] = map_coordinates_artefact
-    # expected_slice[:, 0] = map_coordinates_artefact
-
     slices, xyz_rotated_planes = test_ir.generate_slices(
         map_plane_ones, xy_plane, n_pix, rot_180deg_about_z
     )

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -92,7 +92,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix**2)
+    assert xy_plane.shape == (3, n_pix ** 2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -105,6 +105,11 @@ def test_generate_xy_plane(test_ir, n_pix):
 
 def test_generate_slices(test_ir, n_particles, n_pix):
     """Test generation of slices.
+
+    The artefact values the slices that are zero depend on the rotation
+    and can be the values at -n/2 in any coordinate. The tests should pass
+    if these are excluded in the assert,
+    i.e. np.allclose(expected_slice[1:,1:], returned_slice[1:,1:])
 
     1. Shape test.
 
@@ -125,7 +130,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     xy_plane = test_ir.generate_xy_plane(n_pix)
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, n_pix, rots)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
 
     map_3d_dc = np.zeros((n_pix, n_pix, n_pix))
     rand_val = np.random.uniform(low=1, high=2)


### PR DESCRIPTION
Fixes https://github.com/compSPI/reconstructSPI/issues/15