### PR TITLE
Wiener Filter Tuning

### DIFF
--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -725,7 +725,7 @@ class IterativeRefinement:
         else:
             a, b = center
             nx0, nx1 = shape
-            x0, x1 = np.ogrid[-a : nx0 - 1, -b : nx1 - b]
+            x0, x1 = np.ogrid[-a : nx0 - a, -b : nx1 - b]
             r2 = x0**2 + x1**2
         mask = r2 <= radius**2
         if not fill and radius - shell_thickness > 0:

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -128,8 +128,12 @@ class IterativeRefinement:
             .reshape(map_shape)
         )
 
-        wiener_small_numbers_1 = IterativeRefinement.get_wiener_small_numbers(particles_f_1, ctfs_1)
-        wiener_small_numbers_2 = IterativeRefinement.get_wiener_small_numbers(particles_f_2, ctfs_2)
+        wiener_small_numbers_1 = IterativeRefinement.get_wiener_small_numbers(
+            particles_f_1, ctfs_1
+        )
+        wiener_small_numbers_2 = IterativeRefinement.get_wiener_small_numbers(
+            particles_f_2, ctfs_2
+        )
 
         for _ in range(self.max_itr):
 

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -591,7 +591,8 @@ class IterativeRefinement:
         small_number : float
             Small number for approximating wiener filter effects
         fill_zeros : float
-            Small number used in place of zeros that come from small number computations.
+            Small number used in place of zeros that come from small number
+            computations.
 
         Returns
         -------
@@ -614,7 +615,10 @@ class IterativeRefinement:
 
         Uses section 2.6:
 
-        Sindelar, C. V., & Grigorieff, N. (2011). An adaptation of the Wiener filter suitable for analyzing images of isolated single particles. Journal of Structural Biology, 176(1), 60–74. http://doi.org/10.1016/j.jsb.2011.06.010
+        Sindelar, C. V., & Grigorieff, N. (2011). An adaptation of the Wiener
+        filter suitable for analyzing images of isolated single particles.
+        Journal of Structural Biology, 176(1), 60–74.
+        http://doi.org/10.1016/j.jsb.2011.06.010
 
         Parameters
         ----------

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -128,8 +128,12 @@ class IterativeRefinement:
             .reshape(map_shape)
         )
 
-        wiener_small_numbers = IterativeRefinement.compute_ssnr(self.particles, ctfs, 0.01)
-        wiener_small_numbers = np.where(wiener_small_numbers == 0, 0.1, wiener_small_numbers)
+        wiener_small_numbers = IterativeRefinement.compute_ssnr(
+            self.particles, ctfs, 0.01
+        )
+        wiener_small_numbers = np.where(
+            wiener_small_numbers == 0, 0.1, wiener_small_numbers
+        )
         wiener_small_numbers = 1 / wiener_small_numbers
 
         for _ in range(self.max_itr):
@@ -583,7 +587,7 @@ class IterativeRefinement:
         return projection_wfilter_f
 
     @staticmethod
-    def compute_ssnr(projections, ctfs, small_number = 0.01):
+    def compute_ssnr(projections, ctfs, small_number=0.01):
         """Compute spectral signal to noise ratio (SSNR) for each pixel of projections.
 
         Uses section 2.6:
@@ -605,7 +609,9 @@ class IterativeRefinement:
         """
         n_pix = len(projections[0])
 
-        signal_values = np.sum(ctfs * projections, axis=0) / np.sum(ctfs ** 2 + small_number, axis=0)
+        signal_values = np.sum(ctfs * projections, axis=0) / np.sum(
+            ctfs**2 + small_number, axis=0
+        )
 
         ctf_sq_sum = np.zeros(len(projections) // 2)
         ctf_img_sq_sum = np.zeros(len(projections) // 2)
@@ -613,19 +619,24 @@ class IterativeRefinement:
         shell_pixels = np.zeros(len(projections) // 2)
 
         for R in range(len(projections) // 2):
-            mask = IterativeRefinement.binary_mask((n_pix // 2, n_pix // 2), R, projections[0].shape, 2)
+            mask = IterativeRefinement.binary_mask(
+                (n_pix // 2, n_pix // 2), R, projections[0].shape, 2
+            )
             ctf_sq_sum[R] = np.sum(mask * np.sum(ctfs**2, axis=0))
-            ctf_img_sq_sum[R] = np.sum(mask * np.sum(ctfs**2 * np.abs(projections)**2, axis=0))
-            diff_sq_sum[R] = np.sum(mask * np.sum(np.abs(projections - ctfs * signal_values)**2, axis=0))
+            ctf_img_sq_sum[R] = np.sum(
+                mask * np.sum(ctfs**2 * np.abs(projections) ** 2, axis=0)
+            )
+            diff_sq_sum[R] = np.sum(
+                mask * np.sum(np.abs(projections - ctfs * signal_values) ** 2, axis=0)
+            )
             shell_pixels[R] = np.sum(mask)
 
         sigma_rs_2 = ctf_img_sq_sum / ctf_sq_sum
         sigma_rn_2 = diff_sq_sum / (shell_pixels * (len(projections) - 1))
 
-        ssnr_1d =  (sigma_rs_2 / sigma_rn_2) - shell_pixels / ctf_sq_sum
+        ssnr_1d = (sigma_rs_2 / sigma_rn_2) - shell_pixels / ctf_sq_sum
 
         return IterativeRefinement.expand_1d_to_Nd(ssnr_1d, d=2)
-
 
     @staticmethod
     def insert_slice(slice_real, xyz, n_pix):
@@ -701,7 +712,7 @@ class IterativeRefinement:
             shape (d,)
             the shape of the outputted 3D array.
         d : int
-            number of dimensions - 2 or 3. 
+            number of dimensions - 2 or 3.
         fill : bool
             Whether to output a shell or a solid sphere.
         shell_thickness : bool
@@ -740,7 +751,7 @@ class IterativeRefinement:
         arr_1d : arr
             Shape (n_pix // 2)
         d : int
-            number of dimensions - 2 or 3. 
+            number of dimensions - 2 or 3.
 
         Returns
         -------

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -605,7 +605,7 @@ class IterativeRefinement:
         """
         n_pix = len(projections[0])
 
-        signal_values = np.sum(ctfs * projections, axis=0) / np.sum(ctfs ** 2 + small_number, axis=0)
+        signal_values = np.sum(ctfs * projections, axis=0) / np.sum(ctfs * ctfs + small_number, axis=0)
 
         ctf_sq_sum = np.zeros(len(projections) // 2)
         ctf_img_sq_sum = np.zeros(len(projections) // 2)
@@ -614,9 +614,9 @@ class IterativeRefinement:
 
         for R in range(len(projections) // 2):
             mask = IterativeRefinement.binary_mask((n_pix // 2, n_pix // 2), R, projections[0].shape, 2)
-            ctf_sq_sum[R] = np.sum(mask * np.sum(ctfs**2, axis=0))
-            ctf_img_sq_sum[R] = np.sum(mask * np.sum(ctfs**2 * np.abs(projections)**2, axis=0))
-            diff_sq_sum[R] = np.sum(mask * np.sum(np.abs(projections - ctfs * signal_values)**2, axis=0))
+            ctf_sq_sum[R] = np.sum(mask * np.sum(ctfs * ctfs, axis=0))
+            ctf_img_sq_sum[R] = np.sum(mask * np.sum(ctfs * ctfs * np.abs(projections) * np.abs(projections), axis=0))
+            diff_sq_sum[R] = np.sum(mask * np.sum(np.abs(projections - ctfs * signal_values) * np.sum(np.abs(projections - ctfs * signal_values)), axis=0))
             shell_pixels[R] = np.sum(mask)
 
         sigma_rs_2 = ctf_img_sq_sum / ctf_sq_sum

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -644,7 +644,7 @@ class IterativeRefinement:
 
         for radius in range(n_pix // 2):
             mask = IterativeRefinement.binary_mask(
-                (n_pix // 2, n_pix // 2), R, projections_f[0].shape, 2
+                (n_pix // 2, n_pix // 2), radius, projections_f[0].shape, 2
             )
             ctf_sq_sum[radius] = np.sum(mask * np.sum(ctfs**2, axis=0))
             ctf_img_sq_sum[radius] = np.sum(

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -625,14 +625,11 @@ class IterativeRefinement:
             )
             ctf_sq_sum[R] = np.sum(mask * np.sum(ctfs**2, axis=0))
             ctf_img_sq_sum[R] = np.sum(
-                mask
-                * np.sum(
-                    ctfs**2 * np.abs(projections)**2, axis=0
-                )
+                mask * np.sum(ctfs**2 * np.abs(projections) ** 2, axis=0)
             )
-            diff_sq_sum[R] = np.sum(mask * np.sum(
-                np.abs(projections - ctfs * signal_values)**2, axis=0
-            ))
+            diff_sq_sum[R] = np.sum(
+                mask * np.sum(np.abs(projections - ctfs * signal_values) ** 2, axis=0)
+            )
             shell_pixels[R] = np.sum(mask)
 
         sigma_rs_2 = ctf_img_sq_sum / ctf_sq_sum

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -614,10 +614,10 @@ class IterativeRefinement:
             ctfs * ctfs + small_number, axis=0
         )
 
-        ctf_sq_sum = np.zeros(len(projections) // 2)
-        ctf_img_sq_sum = np.zeros(len(projections) // 2)
-        diff_sq_sum = np.zeros(len(projections) // 2)
-        shell_pixels = np.zeros(len(projections) // 2)
+        ctf_sq_sum = np.zeros(n_pix // 2)
+        ctf_img_sq_sum = np.zeros(n_pix // 2)
+        diff_sq_sum = np.zeros(n_pix // 2)
+        shell_pixels = np.zeros(n_pix // 2)
 
         for R in range(n_pix // 2):
             mask = IterativeRefinement.binary_mask(

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -128,7 +128,6 @@ class IterativeRefinement:
             .reshape(map_shape)
         )
 
-
         wiener_small_numbers = self.get_wiener_small_numbers(ctfs, 0.01, 0.1)
 
         for _ in range(self.max_itr):
@@ -593,7 +592,7 @@ class IterativeRefinement:
             Small number for approximating wiener filter effects
         fill_zeros : float
             Small number used in place of zeros that come from small number computations.
-        
+
         Returns
         -------
         wiener_small_numbers : arr
@@ -614,13 +613,13 @@ class IterativeRefinement:
         """Compute spectral signal to noise ratio (SSNR) for each pixel of projections.
 
         Uses section 2.6:
-        
+
         Sindelar, C. V., & Grigorieff, N. (2011). An adaptation of the Wiener filter suitable for analyzing images of isolated single particles. Journal of Structural Biology, 176(1), 60–74. http://doi.org/10.1016/j.jsb.2011.06.010
 
         Parameters
         ----------
         projections_f : arr
-            projections in fourier space. 
+            projections in fourier space.
             Shape (n_projections, n_pix, n_pix)
         ctfs : arr
             Shape (n_ctfs, n_pix, n_pix)
@@ -750,7 +749,7 @@ class IterativeRefinement:
             An array of bools with "True" where the sphere mask is
             present.
         """
-        if d not in (2,3):
+        if d not in (2, 3):
             raise ValueError(f"Dimension {d} was not 2 or 3")
         if d == 3:
             a, b, c = center

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -314,7 +314,7 @@ class IterativeRefinement:
         """
         fsc_1d = IterativeRefinement.compute_fsc(map_3d_f_norm_1, map_3d_f_norm_2)
 
-        fsc_3d = IterativeRefinement.expand_1d_to_3d(fsc_1d)
+        fsc_3d = IterativeRefinement.expand_1d_to_Nd(fsc_1d)
 
         map_3d_f_filtered_1 = map_3d_f_norm_1 * fsc_3d
         map_3d_f_filtered_2 = map_3d_f_norm_2 * fsc_3d

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -585,6 +585,7 @@ class IterativeRefinement:
         projection_wfilter_f = projection_f * wfilter
         return projection_wfilter_f
 
+    @staticmethod
     def get_wiener_small_numbers(particles_f, ctfs, small_number=0.01, fill_zeros=0.01):
         """Compute wiener small number array.
 

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -609,7 +609,9 @@ class IterativeRefinement:
         """
         n_pix = len(projections[0])
 
-        signal_values = np.sum(ctfs * projections, axis=0) / np.sum(ctfs * ctfs + small_number, axis=0)
+        signal_values = np.sum(ctfs * projections, axis=0) / np.sum(
+            ctfs * ctfs + small_number, axis=0
+        )
 
         ctf_sq_sum = np.zeros(len(projections) // 2)
         ctf_img_sq_sum = np.zeros(len(projections) // 2)
@@ -617,10 +619,24 @@ class IterativeRefinement:
         shell_pixels = np.zeros(len(projections) // 2)
 
         for R in range(len(projections) // 2):
-            mask = IterativeRefinement.binary_mask((n_pix // 2, n_pix // 2), R, projections[0].shape, 2)
+            mask = IterativeRefinement.binary_mask(
+                (n_pix // 2, n_pix // 2), R, projections[0].shape, 2
+            )
             ctf_sq_sum[R] = np.sum(mask * np.sum(ctfs * ctfs, axis=0))
-            ctf_img_sq_sum[R] = np.sum(mask * np.sum(ctfs * ctfs * np.abs(projections) * np.abs(projections), axis=0))
-            diff_sq_sum[R] = np.sum(mask * np.sum(np.abs(projections - ctfs * signal_values) * np.sum(np.abs(projections - ctfs * signal_values)), axis=0))
+            ctf_img_sq_sum[R] = np.sum(
+                mask
+                * np.sum(
+                    ctfs * ctfs * np.abs(projections) * np.abs(projections), axis=0
+                )
+            )
+            diff_sq_sum[R] = np.sum(
+                mask
+                * np.sum(
+                    np.abs(projections - ctfs * signal_values)
+                    * np.sum(np.abs(projections - ctfs * signal_values)),
+                    axis=0,
+                )
+            )
             shell_pixels[R] = np.sum(mask)
 
         sigma_rs_2 = ctf_img_sq_sum / ctf_sq_sum

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -619,7 +619,7 @@ class IterativeRefinement:
         diff_sq_sum = np.zeros(len(projections) // 2)
         shell_pixels = np.zeros(len(projections) // 2)
 
-        for R in range(len(projections) // 2):
+        for R in range(n_pix // 2):
             mask = IterativeRefinement.binary_mask(
                 (n_pix // 2, n_pix // 2), R, projections[0].shape, 2
             )

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -353,7 +353,7 @@ class IterativeRefinement:
         ctfs = []
 
         for i in range(n_ctfs):
-            ctfs[i] = eval_ctf(**self.ctf_info[i])
+            ctfs.append(eval_ctf(**self.ctf_info[i]))
 
         return np.array(ctfs)
 

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -257,8 +257,8 @@ def test_compute_fsc(test_ir, n_pix):
     assert fsc_1.shape == (n_pix // 2,)
 
 
-def test_binary_mask_3d(test_ir):
-    """Test binary_mask_3d.
+def test_binary_mask(test_ir):
+    """Test binary_mask in 3d.
 
     Tests the limit of infinite n_pix. Use high n_pix so good approx.
     1. Sums shell through an axis, then converts to circle,
@@ -276,8 +276,8 @@ def test_binary_mask_3d(test_ir):
     radius = n_pix // 2
     shape = (n_pix, n_pix, n_pix)
     for fill in [True, False]:
-        mask = test_ir.binary_mask_3d(
-            center, radius, shape, fill=fill, shell_thickness=1
+        mask = test_ir.binary_mask(
+            center, radius, shape, 3,  fill=fill, shell_thickness=1
         )
 
         for axis in [0, 1, 2]:
@@ -285,18 +285,18 @@ def test_binary_mask_3d(test_ir):
             circle_to_square_ratio = circle.mean()
             assert np.isclose(circle_to_square_ratio, np.pi / 4, atol=1e-3)
 
-    mask = test_ir.binary_mask_3d(center, radius, shape, fill=True, shell_thickness=1)
+    mask = test_ir.binary_mask(center, radius, shape, 3, fill=True, shell_thickness=1)
     circle = mask[n_pix // 2]
     circle_to_square_ratio = circle.mean()
     assert np.isclose(circle_to_square_ratio, np.pi / 4, atol=1e-3)
 
     r_half = radius / 2
     for shell_thickness in [1, 2]:
-        mask_r = test_ir.binary_mask_3d(
-            center, radius, shape, fill=False, shell_thickness=1
+        mask_r = test_ir.binary_mask(
+            center, radius, shape, 3, fill=False, shell_thickness=1
         )
-        mask_r_half = test_ir.binary_mask_3d(
-            center, r_half, shape, fill=False, shell_thickness=1
+        mask_r_half = test_ir.binary_mask(
+            center, r_half, shape, 3, fill=False, shell_thickness=1
         )
         perimeter_ratio = mask_r[n_pix // 2].sum() / mask_r_half[n_pix // 2].sum()
         assert np.isclose(2, perimeter_ratio, atol=0.1)
@@ -312,19 +312,19 @@ def test_binary_mask_3d(test_ir):
         surface_area_ratio_analytic = (radius / r_half) ** 2
         assert np.isclose(surface_area_ratio, surface_area_ratio_analytic, atol=0.1)
 
-    mask_r = test_ir.binary_mask_3d(center, radius, shape, fill=True, shell_thickness=1)
-    mask_r_half = test_ir.binary_mask_3d(
-        center, r_half, shape, fill=True, shell_thickness=1
+    mask_r = test_ir.binary_mask(center, radius, shape, 3, fill=True, shell_thickness=1)
+    mask_r_half = test_ir.binary_mask(
+        center, r_half, shape, 3, fill=True, shell_thickness=1
     )
     volume_ratio = mask_r.sum() / mask_r_half.sum()
     volume_ratio_analytic = (radius / r_half) ** 3
     assert np.isclose(volume_ratio, volume_ratio_analytic, atol=0.005)
 
 
-def test_expand_1d_to_3d(test_ir, n_pix):
-    """Test expansion of 1D array into spherical shell."""
+def test_expand_1d_to_Nd(test_ir, n_pix):
+    """Test expansion of 1D array into spherical or circular shell."""
     for arr_1d in [np.ones(n_pix // 2), np.arange(n_pix // 2)]:
-        arr_3d = test_ir.expand_1d_to_3d(arr_1d)
+        arr_3d = test_ir.expand_1d_to_Nd(arr_1d, d=3)
 
         assert arr_3d.shape == (n_pix, n_pix, n_pix)
         assert np.allclose(arr_1d, arr_3d[n_pix // 2 :, n_pix // 2, n_pix // 2])
@@ -345,6 +345,24 @@ def test_expand_1d_to_3d(test_ir, n_pix):
         )
         assert np.allclose(
             arr_1d_rev, arr_3d[n_pix // 2, n_pix // 2, 1 : n_pix // 2 + 1]
+        )
+
+        arr_2d = test_ir.expand_1d_to_Nd(arr_1d, d=2)
+
+        assert arr_2d.shape == (n_pix, n_pix)
+        assert np.allclose(arr_1d, arr_2d[n_pix // 2 :, n_pix // 2])
+        assert np.allclose(arr_1d, arr_2d[n_pix // 2, n_pix // 2])
+
+        zeros_1d = np.zeros((n_pix))
+        assert np.allclose(zeros_1d, arr_2d[0, :])
+        assert np.allclose(zeros_1d, arr_2d[:, 0])
+
+        arr_1d_rev = arr_1d[::-1]
+        assert np.allclose(
+            arr_1d_rev, arr_2d[1 : n_pix // 2 + 1, n_pix // 2]
+        )
+        assert np.allclose(
+            arr_1d_rev, arr_2d[n_pix // 2, 1 : n_pix // 2 + 1]
         )
 
 

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -351,7 +351,7 @@ def test_expand_1d_to_Nd(test_ir, n_pix):
 
         assert arr_2d.shape == (n_pix, n_pix)
         assert np.allclose(arr_1d, arr_2d[n_pix // 2 :, n_pix // 2])
-        assert np.allclose(arr_1d, arr_2d[n_pix // 2, n_pix // 2])
+        assert np.allclose(arr_1d, arr_2d[n_pix // 2, n_pix // 2 :])
 
         zeros_1d = np.zeros((n_pix))
         assert np.allclose(zeros_1d, arr_2d[0, :])

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -415,7 +415,7 @@ def test_expand_1d_to_nd(test_ir, n_pix):
 
 
 def test_compute_ssnr(test_ir, n_pix, n_particles):
-    """Test the shape of compute_ssnr"""
+    """Test the shape of compute_ssnr."""
     particles_f = (
         primal_to_fourier_2D(
             torch.from_numpy(test_ir.particles.reshape((n_particles, 1, n_pix, n_pix)))
@@ -429,7 +429,7 @@ def test_compute_ssnr(test_ir, n_pix, n_particles):
 
 
 def test_compute_wiener_small_numbers(test_ir, n_pix, n_particles):
-    """Test the shape of compute_wiener_small_numbers"""
+    """Test the shape of compute_wiener_small_numbers."""
     particles_f = (
         primal_to_fourier_2D(
             torch.from_numpy(test_ir.particles.reshape((n_particles, 1, n_pix, n_pix)))

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -321,7 +321,7 @@ def test_binary_mask(test_ir):
     volume_ratio_analytic = (radius / r_half) ** 3
     assert np.isclose(volume_ratio, volume_ratio_analytic, atol=0.005)
 
-    # 2D tests 
+    # 2D tests
     center = (n_pix // 2, n_pix // 2)
     radius = n_pix // 2
     shape = (n_pix, n_pix)
@@ -329,7 +329,7 @@ def test_binary_mask(test_ir):
         mask = test_ir.binary_mask(
             center, radius, shape, 2, fill=fill, shell_thickness=1
         )
-        
+
         circle_to_square_ratio = mask.sum() > 0
         assert np.isclose(circle_to_square_ratio, np.pi / 4, atol=1e-3)
 
@@ -344,12 +344,8 @@ def test_binary_mask(test_ir):
         perimeter_ratio = mask_r.sum() / mask_r_half.sum()
         assert np.isclose(2, perimeter_ratio, atol=0.1)
         if shell_thickness == 1:
-            assert np.isclose(
-                mask_r.sum() / (2 * np.pi * radius), 1, atol=0.1
-            )
-            assert np.isclose(
-                mask_r_half.sum() / (2 * np.pi * r_half), 1, atol=0.1
-            )
+            assert np.isclose(mask_r.sum() / (2 * np.pi * radius), 1, atol=0.1)
+            assert np.isclose(mask_r_half.sum() / (2 * np.pi * r_half), 1, atol=0.1)
 
     mask_r = test_ir.binary_mask(center, radius, shape, 3, fill=True, shell_thickness=1)
     mask_r_half = test_ir.binary_mask(
@@ -414,6 +410,7 @@ def test_expand_1d_to_nd(test_ir, n_pix):
         except ValueError:
             exceptionThrown = True
         assert exceptionThrown
+
 
 def test_iterative_refinement(test_ir, n_pix):
     """Test complete iterative refinement algorithm."""

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -277,7 +277,7 @@ def test_binary_mask(test_ir):
     shape = (n_pix, n_pix, n_pix)
     for fill in [True, False]:
         mask = test_ir.binary_mask(
-            center, radius, shape, 3,  fill=fill, shell_thickness=1
+            center, radius, shape, 3, fill=fill, shell_thickness=1
         )
 
         for axis in [0, 1, 2]:
@@ -358,12 +358,8 @@ def test_expand_1d_to_Nd(test_ir, n_pix):
         assert np.allclose(zeros_1d, arr_2d[:, 0])
 
         arr_1d_rev = arr_1d[::-1]
-        assert np.allclose(
-            arr_1d_rev, arr_2d[1 : n_pix // 2 + 1, n_pix // 2]
-        )
-        assert np.allclose(
-            arr_1d_rev, arr_2d[n_pix // 2, 1 : n_pix // 2 + 1]
-        )
+        assert np.allclose(arr_1d_rev, arr_2d[1 : n_pix // 2 + 1, n_pix // 2])
+        assert np.allclose(arr_1d_rev, arr_2d[n_pix // 2, 1 : n_pix // 2 + 1])
 
 
 def test_iterative_refinement(test_ir, n_pix):

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -258,7 +258,7 @@ def test_compute_fsc(test_ir, n_pix):
 
 
 def test_binary_mask(test_ir):
-    """Test binary_mask in 3d.
+    """Test binary_mask in 3d and 2d.
 
     Tests the limit of infinite n_pix. Use high n_pix so good approx.
     1. Sums shell through an axis, then converts to circle,
@@ -270,6 +270,7 @@ def test_binary_mask(test_ir):
 
     3. Make filled sphere of sizes r and r/2 and check ratio of volume.
     """
+    # 3D tests
     n_pix = 512
 
     center = (n_pix // 2, n_pix // 2, n_pix // 2)
@@ -320,11 +321,57 @@ def test_binary_mask(test_ir):
     volume_ratio_analytic = (radius / r_half) ** 3
     assert np.isclose(volume_ratio, volume_ratio_analytic, atol=0.005)
 
+    # 2D tests 
+    center = (n_pix // 2, n_pix // 2)
+    radius = n_pix // 2
+    shape = (n_pix, n_pix)
+    for fill in [True, False]:
+        mask = test_ir.binary_mask(
+            center, radius, shape, 2, fill=fill, shell_thickness=1
+        )
+        
+        circle_to_square_ratio = mask.sum() > 0
+        assert np.isclose(circle_to_square_ratio, np.pi / 4, atol=1e-3)
 
-def test_expand_1d_to_Nd(test_ir, n_pix):
+    r_half = radius / 2
+    for shell_thickness in [1, 2]:
+        mask_r = test_ir.binary_mask(
+            center, radius, shape, 2, fill=False, shell_thickness=1
+        )
+        mask_r_half = test_ir.binary_mask(
+            center, r_half, shape, 2, fill=False, shell_thickness=1
+        )
+        perimeter_ratio = mask_r.sum() / mask_r_half.sum()
+        assert np.isclose(2, perimeter_ratio, atol=0.1)
+        if shell_thickness == 1:
+            assert np.isclose(
+                mask_r.sum() / (2 * np.pi * radius), 1, atol=0.1
+            )
+            assert np.isclose(
+                mask_r_half.sum() / (2 * np.pi * r_half), 1, atol=0.1
+            )
+
+    mask_r = test_ir.binary_mask(center, radius, shape, 3, fill=True, shell_thickness=1)
+    mask_r_half = test_ir.binary_mask(
+        center, r_half, shape, 2, fill=True, shell_thickness=1
+    )
+    area_ratio = mask_r.sum() / mask_r_half.sum()
+    area_ratio_analytic = (radius / r_half) ** 2
+    assert np.isclose(area_ratio, area_ratio_analytic, atol=0.005)
+
+    # ND test
+    exceptionThrown = False
+    try:
+        arr_nd = test_ir.binary_mask(center, radius, shape, 4)
+    except ValueError:
+        exceptionThrown = True
+    assert exceptionThrown
+
+
+def test_expand_1d_to_nd(test_ir, n_pix):
     """Test expansion of 1D array into spherical or circular shell."""
     for arr_1d in [np.ones(n_pix // 2), np.arange(n_pix // 2)]:
-        arr_3d = test_ir.expand_1d_to_Nd(arr_1d, d=3)
+        arr_3d = test_ir.expand_1d_to_nd(arr_1d, d=3)
 
         assert arr_3d.shape == (n_pix, n_pix, n_pix)
         assert np.allclose(arr_1d, arr_3d[n_pix // 2 :, n_pix // 2, n_pix // 2])
@@ -347,7 +394,7 @@ def test_expand_1d_to_Nd(test_ir, n_pix):
             arr_1d_rev, arr_3d[n_pix // 2, n_pix // 2, 1 : n_pix // 2 + 1]
         )
 
-        arr_2d = test_ir.expand_1d_to_Nd(arr_1d, d=2)
+        arr_2d = test_ir.expand_1d_to_nd(arr_1d, d=2)
 
         assert arr_2d.shape == (n_pix, n_pix)
         assert np.allclose(arr_1d, arr_2d[n_pix // 2 :, n_pix // 2])
@@ -361,6 +408,12 @@ def test_expand_1d_to_Nd(test_ir, n_pix):
         assert np.allclose(arr_1d_rev, arr_2d[1 : n_pix // 2 + 1, n_pix // 2])
         assert np.allclose(arr_1d_rev, arr_2d[n_pix // 2, 1 : n_pix // 2 + 1])
 
+        exceptionThrown = False
+        try:
+            arr_nd = test_ir.expand_1d_to_nd(arr1d, d=4)
+        except ValueError:
+            exceptionThrown = True
+        assert exceptionThrown
 
 def test_iterative_refinement(test_ir, n_pix):
     """Test complete iterative refinement algorithm."""

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -358,7 +358,7 @@ def test_binary_mask(test_ir):
     # ND test
     exceptionThrown = False
     try:
-        arr_nd = test_ir.binary_mask(center, radius, shape, 4)
+        test_ir.binary_mask(center, radius, shape, 4)
     except ValueError:
         exceptionThrown = True
     assert exceptionThrown
@@ -406,7 +406,8 @@ def test_expand_1d_to_nd(test_ir, n_pix):
 
         exceptionThrown = False
         try:
-            arr_nd = test_ir.expand_1d_to_nd(arr1d, d=4)
+            arr_1d = np.arange(n_pix // 2)
+            test_ir.expand_1d_to_nd(arr_1d, d=4)
         except ValueError:
             exceptionThrown = True
         assert exceptionThrown

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -325,13 +325,14 @@ def test_binary_mask(test_ir):
     center = (n_pix // 2, n_pix // 2)
     radius = n_pix // 2
     shape = (n_pix, n_pix)
-    for fill in [True, False]:
-        mask = test_ir.binary_mask(
-            center, radius, shape, 2, fill=fill, shell_thickness=1
-        )
+    
+    mask = test_ir.binary_mask(
+        center, radius, shape, 2, fill=True, shell_thickness=1
+    )
 
-        circle_to_square_ratio = mask.sum() > 0
-        assert np.isclose(circle_to_square_ratio, np.pi / 4, atol=1e-3)
+    circle = mask > 0
+    circle_to_square_ratio = circle.mean()
+    assert np.isclose(circle_to_square_ratio, np.pi / 4, atol=1e-3)
 
     r_half = radius / 2
     for shell_thickness in [1, 2]:
@@ -347,7 +348,7 @@ def test_binary_mask(test_ir):
             assert np.isclose(mask_r.sum() / (2 * np.pi * radius), 1, atol=0.1)
             assert np.isclose(mask_r_half.sum() / (2 * np.pi * r_half), 1, atol=0.1)
 
-    mask_r = test_ir.binary_mask(center, radius, shape, 3, fill=True, shell_thickness=1)
+    mask_r = test_ir.binary_mask(center, radius, shape, 2, fill=True, shell_thickness=1)
     mask_r_half = test_ir.binary_mask(
         center, r_half, shape, 2, fill=True, shell_thickness=1
     )

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -2,6 +2,12 @@
 
 import numpy as np
 import pytest
+import torch
+from compSPI.transforms import (
+    fourier_to_primal_3D,
+    primal_to_fourier_2D,
+    primal_to_fourier_3D,
+)
 
 from reconstructSPI.iterative_refinement import expectation_maximization as em
 
@@ -410,6 +416,34 @@ def test_expand_1d_to_nd(test_ir, n_pix):
         except ValueError:
             exceptionThrown = True
         assert exceptionThrown
+
+
+def test_compute_ssnr(test_ir, n_pix, n_particles):
+    """Test the shape of compute_ssnr"""
+    particles_f = (
+        primal_to_fourier_2D(
+            torch.from_numpy(test_ir.particles.reshape((n_particles, 1, n_pix, n_pix)))
+        )
+        .numpy()
+        .reshape((n_particles, n_pix, n_pix))
+    )
+    ctfs = test_ir.build_ctf_array()
+    ssnrs = test_ir.compute_ssnr(particles_f, ctfs)
+    assert ssnrs.shape == (n_pix, n_pix)
+
+
+def test_compute_wiener_small_numbers(test_ir, n_pix, n_particles):
+    """Test the shape of compute_wiener_small_numbers"""
+    particles_f = (
+        primal_to_fourier_2D(
+            torch.from_numpy(test_ir.particles.reshape((n_particles, 1, n_pix, n_pix)))
+        )
+        .numpy()
+        .reshape((n_particles, n_pix, n_pix))
+    )
+    ctfs = test_ir.build_ctf_array()
+    small_numbers = test_ir.get_wiener_small_numbers(particles_f, ctfs)
+    assert small_numbers.shape == (n_pix, n_pix)
 
 
 def test_iterative_refinement(test_ir, n_pix):

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -325,10 +325,8 @@ def test_binary_mask(test_ir):
     center = (n_pix // 2, n_pix // 2)
     radius = n_pix // 2
     shape = (n_pix, n_pix)
-    
-    mask = test_ir.binary_mask(
-        center, radius, shape, 2, fill=True, shell_thickness=1
-    )
+
+    mask = test_ir.binary_mask(center, radius, shape, 2, fill=True, shell_thickness=1)
 
     circle = mask > 0
     circle_to_square_ratio = circle.mean()

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -3,11 +3,7 @@
 import numpy as np
 import pytest
 import torch
-from compSPI.transforms import (
-    fourier_to_primal_3D,
-    primal_to_fourier_2D,
-    primal_to_fourier_3D,
-)
+from compSPI.transforms import primal_to_fourier_2D
 
 from reconstructSPI.iterative_refinement import expectation_maximization as em
 


### PR DESCRIPTION
See #17 

Followed https://doi.org/10.1016/j.jsb.2011.06.010. 

This involved using the spectral signal-to-noise ratio (SSNR) to tune the wiener filter based on the projections and ctfs inputted into the system. 

Also included are expanding the expand_1d_to_3d and binary_mask_3d methods to work with 2d as well, as this was useful when computing the SSNR.