### PR TITLE
iterative ref: build_ctf_array

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,6 @@ dependencies:
   - pytorch
   - scipy
   - pip :
-      - git+https://github.com/compSPI/simSPI/tree/init.git
+      - git+https://github.com/compSPI/simSPI.git@init
       - git+https://github.com/compSPI/compSPI.git
       - geomstats

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,6 @@ dependencies:
   - pytorch
   - scipy
   - pip :
-      - git+https://github.com/compSPI/simSPI.git
+      - git+https://github.com/compSPI/simSPI/tree/init.git
       - git+https://github.com/compSPI/compSPI.git
       - geomstats

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -363,24 +363,6 @@ class IterativeRefinement:
                 super().__init__(*args, **kwargs)
                 self.__dict__ = self
 
-        # this is self.ctf_info, need to confirm changes
-        # cfg_dict = {  # these values will be in self.ctf_info
-        #     'amplitude_contrast': 0.1,
-        #     'b_factor': 0.0,
-        #     'batch_size': len(self.particles),
-        #     'cs': 2.7,
-        #     'ctf_size': 32,  # n_pix
-        #     'kv': 300,
-        #     'pixel_size': 3.2,
-        #     'side_len': 32,
-        #     'value_nyquist': 0.1,
-        #     'ctf_params' : {  # user would also pass this part in
-        #         'defocus_u' : [],
-        #         'defocus_v' : [],
-        #         'defocus_angle' : [],
-        #     }
-        # }
-
         ctf = CTF(AttrDict(self.ctf_info))
         tensor_shape = (len(self.particles), 1, 1, 1)
         tensor_dict = {}

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -24,32 +24,9 @@ class IterativeRefinement:
         Particles to be reconstructed.
         Shape (n_particles, n_pix, n_pix)
     ctf_info : dict
-        dict containing CTF config and parameters
-            amplitude_contrast : float
-                contrast
-            b_factor : float
-                b factor
-            batch_size : int
-                num of particles
-            cs : float
-                cs
-            ctf_size : int
-                ctf size
-            kv : float
-                angstroms
-            pixel_size : int
-                range [128, 256]
-            side_len : int
-                side length
-            value_nyquist : float
-                how far out in Fourier space
-            ctf_params : dict
-                defocus_u : list of floats
-                    range [0.5, 2.5]
-                defocus_v : list of floats
-                    range [0.5, 2.5]
-                defocus_angle : list of floats
-                    range [0, 2pi]
+        dict containing CTF config and parameters.
+        See https://github.com/compSPI/simSPI/blob/master/simSPI/linear_simulator/ctf.py
+        for full documentation and parameter restrictions.
 
 
     References

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -285,7 +285,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts**2)
+        return map_3d * counts / (norm_const + counts ** 2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -375,9 +375,8 @@ class IterativeRefinement:
             self.particles.shape[1],
             self.particles.shape[2],
         )
-        ctfs = ctf.get_ctf(tensor_dict).numpy().reshape(ctf_shape)
 
-        return ctfs.numpy()
+        return ctf.get_ctf(tensor_dict).numpy().reshape(ctf_shape)
 
     @staticmethod
     def grid_SO3_uniform(n_rotations):
@@ -424,7 +423,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix**2))
+        xy_plane = np.zeros((3, n_pix ** 2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -506,7 +505,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -572,7 +571,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma**2) ** -1)
+        scale = -((2 * sigma ** 2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -690,8 +689,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0**2 + x1**2 + x2**2
-        mask = r2 <= radius**2
+        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
+        mask = r2 <= radius ** 2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -285,7 +285,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts**2)
+        return map_3d * counts / (norm_const + counts ** 2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -351,6 +351,14 @@ class IterativeRefinement:
         """
 
         class AttrDict(dict):
+            """Class to convert a dictionary to a class.
+
+            Parameters
+            ----------
+            dict: dictionary
+
+            """
+
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
                 self.__dict__ = self
@@ -434,7 +442,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix**2))
+        xy_plane = np.zeros((3, n_pix ** 2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -516,7 +524,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -582,7 +590,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma**2) ** -1)
+        scale = -((2 * sigma ** 2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -700,8 +708,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0**2 + x1**2 + x2**2
-        mask = r2 <= radius**2
+        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
+        mask = r2 <= radius ** 2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -9,8 +9,7 @@ from compSPI.transforms import (
 )
 from geomstats.geometry import special_orthogonal
 from scipy.ndimage import map_coordinates
-from simSPI import crd
-from simSPI import ctf as ctf_module
+from simSPI.linear_simulator import ctf as ctf_module
 
 
 class IterativeRefinement:
@@ -51,7 +50,6 @@ class IterativeRefinement:
         self.particles = particles
         self.ctf_info = ctf_info
         self.max_itr = max_itr
-        print(crd.get_rotlist(1))
 
     def iterative_refinement(self, wiener_small_number=0.01, count_norm_const=1):
         """Perform iterative refinement.

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -315,7 +315,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts**2)
+        return map_3d * counts / (norm_const + counts ** 2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -452,7 +452,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix**2))
+        xy_plane = np.zeros((3, n_pix ** 2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -534,7 +534,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -600,7 +600,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma**2) ** -1)
+        scale = -((2 * sigma ** 2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -704,9 +704,9 @@ class IterativeRefinement:
             mask = IterativeRefinement.binary_mask(
                 (n_pix // 2, n_pix // 2), radius, projections_f[0].shape, 2
             )
-            ctf_sq_sum[radius] = np.sum(mask * np.sum(ctfs**2, axis=0))
+            ctf_sq_sum[radius] = np.sum(mask * np.sum(ctfs ** 2, axis=0))
             ctf_img_sq_sum[radius] = np.sum(
-                mask * np.sum(ctfs**2 * np.abs(projections_f) ** 2, axis=0)
+                mask * np.sum(ctfs ** 2 * np.abs(projections_f) ** 2, axis=0)
             )
             diff_sq_sum[radius] = np.sum(
                 mask * np.sum(np.abs(projections_f - ctfs * signal_values) ** 2, axis=0)
@@ -813,15 +813,15 @@ class IterativeRefinement:
             a, b, c = center
             nx0, nx1, nx2 = shape
             x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-            r2 = x0**2 + x1**2 + x2**2
+            r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
 
         elif d == 2:
             a, b = center
             nx0, nx1 = shape
             x0, x1 = np.ogrid[-a : nx0 - a, -b : nx1 - b]
-            r2 = x0**2 + x1**2
+            r2 = x0 ** 2 + x1 ** 2
 
-        mask = r2 <= radius**2
+        mask = r2 <= radius ** 2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -9,7 +9,7 @@ from compSPI.transforms import (
 )
 from geomstats.geometry import special_orthogonal
 from scipy.ndimage import map_coordinates
-from simSPI.linear_simulator import ctf as ctf_module
+from simSPI import ctf as ctf_module
 
 
 class IterativeRefinement:

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -23,9 +23,8 @@ class IterativeRefinement:
     particles : arr
         Particles to be reconstructed.
         Shape (n_particles, n_pix, n_pix)
-    ctf_info : list of dicts
-        Each dict contains CTF k,v pairs per particle.
-            Shape (n_particles,)
+    ctf_info : dict
+
 
     References
     ----------
@@ -285,7 +284,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts**2)
+        return map_3d * counts / (norm_const + counts ** 2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -423,7 +422,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix**2))
+        xy_plane = np.zeros((3, n_pix ** 2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -505,7 +504,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -571,7 +570,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma**2) ** -1)
+        scale = -((2 * sigma ** 2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -689,8 +688,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0**2 + x1**2 + x2**2
-        mask = r2 <= radius**2
+        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
+        mask = r2 <= radius ** 2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -285,7 +285,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts ** 2)
+        return map_3d * counts / (norm_const + counts**2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -442,7 +442,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix ** 2))
+        xy_plane = np.zeros((3, n_pix**2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -524,7 +524,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -590,7 +590,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma ** 2) ** -1)
+        scale = -((2 * sigma**2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -708,8 +708,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
-        mask = r2 <= radius ** 2
+        r2 = x0**2 + x1**2 + x2**2
+        mask = r2 <= radius**2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -9,7 +9,7 @@ from compSPI.transforms import (
 )
 from geomstats.geometry import special_orthogonal
 from scipy.ndimage import map_coordinates
-from simSPI.linear_simulator.ctf import CTF
+from simSPI.simSPI.linear_simulator.ctf import CTF
 
 
 class IterativeRefinement:
@@ -285,7 +285,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts**2)
+        return map_3d * counts / (norm_const + counts ** 2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -423,7 +423,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix**2))
+        xy_plane = np.zeros((3, n_pix ** 2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -505,7 +505,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -571,7 +571,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma**2) ** -1)
+        scale = -((2 * sigma ** 2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -689,8 +689,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0**2 + x1**2 + x2**2
-        mask = r2 <= radius**2
+        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
+        mask = r2 <= radius ** 2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -285,7 +285,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts ** 2)
+        return map_3d * counts / (norm_const + counts**2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -423,7 +423,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix ** 2))
+        xy_plane = np.zeros((3, n_pix**2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -505,7 +505,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -571,7 +571,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma ** 2) ** -1)
+        scale = -((2 * sigma**2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -689,8 +689,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
-        mask = r2 <= radius ** 2
+        r2 = x0**2 + x1**2 + x2**2
+        mask = r2 <= radius**2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -287,7 +287,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts ** 2)
+        return map_3d * counts / (norm_const + counts**2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -425,7 +425,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix ** 2))
+        xy_plane = np.zeros((3, n_pix**2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -507,7 +507,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -573,7 +573,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma ** 2) ** -1)
+        scale = -((2 * sigma**2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -691,8 +691,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
-        mask = r2 <= radius ** 2
+        r2 = x0**2 + x1**2 + x2**2
+        mask = r2 <= radius**2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -9,7 +9,7 @@ from compSPI.transforms import (
 )
 from geomstats.geometry import special_orthogonal
 from scipy.ndimage import map_coordinates
-from simSPI.simSPI.linear_simulator.ctf import CTF
+from simSPI.linear_simulator import ctf
 
 
 class IterativeRefinement:
@@ -285,7 +285,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts**2)
+        return map_3d * counts / (norm_const + counts ** 2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -363,7 +363,7 @@ class IterativeRefinement:
                 super().__init__(*args, **kwargs)
                 self.__dict__ = self
 
-        ctf = CTF(AttrDict(self.ctf_info))
+        ctf_obj = ctf.CTF(AttrDict(self.ctf_info))
         tensor_shape = (len(self.particles), 1, 1, 1)
         tensor_dict = {}
 
@@ -376,7 +376,7 @@ class IterativeRefinement:
             self.particles.shape[2],
         )
 
-        return ctf.get_ctf(tensor_dict).numpy().reshape(ctf_shape)
+        return ctf_obj.get_ctf(tensor_dict).numpy().reshape(ctf_shape)
 
     @staticmethod
     def grid_SO3_uniform(n_rotations):
@@ -423,7 +423,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix**2))
+        xy_plane = np.zeros((3, n_pix ** 2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -505,7 +505,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -571,7 +571,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma**2) ** -1)
+        scale = -((2 * sigma ** 2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -689,8 +689,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0**2 + x1**2 + x2**2
-        mask = r2 <= radius**2
+        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
+        mask = r2 <= radius ** 2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -24,6 +24,32 @@ class IterativeRefinement:
         Particles to be reconstructed.
         Shape (n_particles, n_pix, n_pix)
     ctf_info : dict
+        dict containing CTF config and parameters
+            amplitude_contrast : float
+                contrast
+            b_factor : float
+                b factor
+            batch_size : int
+                num of particles
+            cs : float
+                cs
+            ctf_size : int
+                ctf size
+            kv : float
+                angstroms
+            pixel_size : int
+                range [128, 256]
+            side_len : int
+                side length
+            value_nyquist : float
+                how far out in Fourier space
+            ctf_params : dict
+                defocus_u : list of floats
+                    range [0.5, 2.5]
+                defocus_v : list of floats
+                    range [0.5, 2.5]
+                defocus_angle : list of floats
+                    range [0, 2pi]
 
 
     References

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -9,7 +9,7 @@ from compSPI.transforms import (
 )
 from geomstats.geometry import special_orthogonal
 from scipy.ndimage import map_coordinates
-from simSPI.linear_simulator import ctf
+from simSPI.linear_simulator import ctf as ctf_module
 
 
 class IterativeRefinement:
@@ -285,7 +285,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts**2)
+        return map_3d * counts / (norm_const + counts ** 2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -363,7 +363,7 @@ class IterativeRefinement:
                 super().__init__(*args, **kwargs)
                 self.__dict__ = self
 
-        ctf_obj = ctf.CTF(AttrDict(self.ctf_info))
+        ctf = ctf_module.CTF(AttrDict(self.ctf_info))
         tensor_shape = (len(self.particles), 1, 1, 1)
         tensor_dict = {}
 
@@ -376,7 +376,7 @@ class IterativeRefinement:
             self.particles.shape[2],
         )
 
-        return ctf_obj.get_ctf(tensor_dict).numpy().reshape(ctf_shape)
+        return ctf.get_ctf(tensor_dict).numpy().reshape(ctf_shape)
 
     @staticmethod
     def grid_SO3_uniform(n_rotations):
@@ -423,7 +423,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix**2))
+        xy_plane = np.zeros((3, n_pix ** 2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -505,7 +505,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -571,7 +571,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma**2) ** -1)
+        scale = -((2 * sigma ** 2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -689,8 +689,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0**2 + x1**2 + x2**2
-        mask = r2 <= radius**2
+        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
+        mask = r2 <= radius ** 2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -284,7 +284,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts ** 2)
+        return map_3d * counts / (norm_const + counts**2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -422,7 +422,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix ** 2))
+        xy_plane = np.zeros((3, n_pix**2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -504,7 +504,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -570,7 +570,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma ** 2) ** -1)
+        scale = -((2 * sigma**2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -688,8 +688,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
-        mask = r2 <= radius ** 2
+        r2 = x0**2 + x1**2 + x2**2
+        mask = r2 <= radius**2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -315,7 +315,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts**2)
+        return map_3d * counts / (norm_const + counts ** 2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -397,7 +397,7 @@ class IterativeRefinement:
         tensor_shape = (len(self.particles), 1, 1, 1)
         tensor_dict = {}
 
-        for k, v in self.ctf_info["ctf_params"]:
+        for k, v in self.ctf_info["ctf_params"].items():
             tensor_dict[k] = torch.from_numpy(v.reshape(tensor_shape))
 
         ctf_shape = (
@@ -452,7 +452,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix**2))
+        xy_plane = np.zeros((3, n_pix ** 2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -534,7 +534,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -600,7 +600,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma**2) ** -1)
+        scale = -((2 * sigma ** 2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -704,9 +704,9 @@ class IterativeRefinement:
             mask = IterativeRefinement.binary_mask(
                 (n_pix // 2, n_pix // 2), radius, projections_f[0].shape, 2
             )
-            ctf_sq_sum[radius] = np.sum(mask * np.sum(ctfs**2, axis=0))
+            ctf_sq_sum[radius] = np.sum(mask * np.sum(ctfs ** 2, axis=0))
             ctf_img_sq_sum[radius] = np.sum(
-                mask * np.sum(ctfs**2 * np.abs(projections_f) ** 2, axis=0)
+                mask * np.sum(ctfs ** 2 * np.abs(projections_f) ** 2, axis=0)
             )
             diff_sq_sum[radius] = np.sum(
                 mask * np.sum(np.abs(projections_f - ctfs * signal_values) ** 2, axis=0)
@@ -813,15 +813,15 @@ class IterativeRefinement:
             a, b, c = center
             nx0, nx1, nx2 = shape
             x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-            r2 = x0**2 + x1**2 + x2**2
+            r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
 
         elif d == 2:
             a, b = center
             nx0, nx1 = shape
             x0, x1 = np.ogrid[-a : nx0 - a, -b : nx1 - b]
-            r2 = x0**2 + x1**2
+            r2 = x0 ** 2 + x1 ** 2
 
-        mask = r2 <= radius**2
+        mask = r2 <= radius ** 2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -9,6 +9,7 @@ from compSPI.transforms import (
 )
 from geomstats.geometry import special_orthogonal
 from scipy.ndimage import map_coordinates
+from simSPI import crd
 from simSPI import ctf as ctf_module
 
 
@@ -50,6 +51,7 @@ class IterativeRefinement:
         self.particles = particles
         self.ctf_info = ctf_info
         self.max_itr = max_itr
+        print(crd.get_rotlist(1))
 
     def iterative_refinement(self, wiener_small_number=0.01, count_norm_const=1):
         """Perform iterative refinement.
@@ -285,7 +287,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts**2)
+        return map_3d * counts / (norm_const + counts ** 2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -423,7 +425,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix**2))
+        xy_plane = np.zeros((3, n_pix ** 2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -505,7 +507,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -571,7 +573,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma**2) ** -1)
+        scale = -((2 * sigma ** 2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -689,8 +691,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0**2 + x1**2 + x2**2
-        mask = r2 <= radius**2
+        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
+        mask = r2 <= radius ** 2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -315,7 +315,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts ** 2)
+        return map_3d * counts / (norm_const + counts**2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -452,7 +452,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix ** 2))
+        xy_plane = np.zeros((3, n_pix**2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -534,7 +534,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -600,7 +600,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma ** 2) ** -1)
+        scale = -((2 * sigma**2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -704,9 +704,9 @@ class IterativeRefinement:
             mask = IterativeRefinement.binary_mask(
                 (n_pix // 2, n_pix // 2), radius, projections_f[0].shape, 2
             )
-            ctf_sq_sum[radius] = np.sum(mask * np.sum(ctfs ** 2, axis=0))
+            ctf_sq_sum[radius] = np.sum(mask * np.sum(ctfs**2, axis=0))
             ctf_img_sq_sum[radius] = np.sum(
-                mask * np.sum(ctfs ** 2 * np.abs(projections_f) ** 2, axis=0)
+                mask * np.sum(ctfs**2 * np.abs(projections_f) ** 2, axis=0)
             )
             diff_sq_sum[radius] = np.sum(
                 mask * np.sum(np.abs(projections_f - ctfs * signal_values) ** 2, axis=0)
@@ -813,15 +813,15 @@ class IterativeRefinement:
             a, b, c = center
             nx0, nx1, nx2 = shape
             x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-            r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
+            r2 = x0**2 + x1**2 + x2**2
 
         elif d == 2:
             a, b = center
             nx0, nx1 = shape
             x0, x1 = np.ogrid[-a : nx0 - a, -b : nx1 - b]
-            r2 = x0 ** 2 + x1 ** 2
+            r2 = x0**2 + x1**2
 
-        mask = r2 <= radius ** 2
+        mask = r2 <= radius**2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/reconstructSPI/iterative_refinement/expectation_maximization.py
+++ b/reconstructSPI/iterative_refinement/expectation_maximization.py
@@ -285,7 +285,7 @@ class IterativeRefinement:
             Shape (n_pix, n_pix, n_pix)
             map normalized by counts.
         """
-        return map_3d * counts / (norm_const + counts ** 2)
+        return map_3d * counts / (norm_const + counts**2)
 
     @staticmethod
     def apply_noise_model(map_3d_f_norm_1, map_3d_f_norm_2):
@@ -434,7 +434,7 @@ class IterativeRefinement:
         axis_pts = np.arange(-n_pix // 2, n_pix // 2)
         grid = np.meshgrid(axis_pts, axis_pts)
 
-        xy_plane = np.zeros((3, n_pix ** 2))
+        xy_plane = np.zeros((3, n_pix**2))
 
         for d in range(2):
             xy_plane[d, :] = grid[d].flatten()
@@ -516,7 +516,7 @@ class IterativeRefinement:
         slices = np.empty((n_rotations, n_pix, n_pix))
         overwrite_empty_with_zero = 0
         slices[:, :, 0] = overwrite_empty_with_zero
-        xyz_rotated = np.empty((n_rotations, 3, n_pix ** 2))
+        xyz_rotated = np.empty((n_rotations, 3, n_pix**2))
         for i in range(n_rotations):
             xyz_rotated[i] = rots[i] @ xy_plane
 
@@ -582,7 +582,7 @@ class IterativeRefinement:
         )
         slices_norm = np.linalg.norm(slices, axis=(1, 2)) ** 2
         particle_norm = np.linalg.norm(particle) ** 2
-        scale = -((2 * sigma ** 2) ** -1)
+        scale = -((2 * sigma**2) ** -1)
         log_bayesian_weights = scale * (slices_norm - 2 * corr_slices_particle)
         offset_safe = log_bayesian_weights.max()
         bayesian_weights = np.exp(log_bayesian_weights - offset_safe)
@@ -700,8 +700,8 @@ class IterativeRefinement:
         a, b, c = center
         nx0, nx1, nx2 = shape
         x0, x1, x2 = np.ogrid[-a : nx0 - a, -b : nx1 - b, -c : nx2 - c]
-        r2 = x0 ** 2 + x1 ** 2 + x2 ** 2
-        mask = r2 <= radius ** 2
+        r2 = x0**2 + x1**2 + x2**2
+        mask = r2 <= radius**2
         if not fill and radius - shell_thickness > 0:
             mask_outer = mask
             mask_inner = r2 <= (radius - shell_thickness) ** 2

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -39,7 +39,7 @@ def test_ir(n_pix, n_particles):
     """Instantiate IterativeRefinement class for testing."""
     defocus_list = rand_defocus
     angle_list = rand_angle_list
-    pixels = n_pix()
+    pixels = n_pix
     ctf_info = {
         "amplitude_contrast": 0.1,
         "b_factor": 0.0,

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -37,8 +37,6 @@ def rand_defocus(n_particles):
 @pytest.fixture
 def test_ir(n_pix, n_particles):
     """Instantiate IterativeRefinement class for testing."""
-    defocus_list = rand_defocus(n_particles)
-    angle_list = rand_angle_list(n_particles)
     pixels = n_pix
     ctf_info = {
         "amplitude_contrast": 0.1,
@@ -51,9 +49,9 @@ def test_ir(n_pix, n_particles):
         "side_len": pixels,
         "value_nyquist": 0.1,
         "ctf_params": {
-            "defocus_u": defocus_list,
-            "defocus_v": defocus_list,
-            "defocus_angle": angle_list,
+            "defocus_u": rand_defocus,
+            "defocus_v": rand_defocus,
+            "defocus_angle": rand_angle_list,
         },
     }
     map_3d = np.zeros((n_pix, n_pix, n_pix))
@@ -98,7 +96,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix**2)
+    assert xy_plane.shape == (3, n_pix ** 2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -136,7 +134,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     xy_plane = test_ir.generate_xy_plane(n_pix)
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, rots)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
 
     map_3d_dc = np.zeros((n_pix, n_pix, n_pix))
     rand_val = np.random.uniform(low=1, high=2)

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -35,7 +35,7 @@ def rand_defocus(n_particles):
 
 
 @pytest.fixture
-def test_ir(n_pix, n_particles):
+def test_ir(n_pix, n_particles, rand_defocus, rand_angle_list):
     """Instantiate IterativeRefinement class for testing."""
     pixels = n_pix
     ctf_info = {

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -78,7 +78,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix ** 2)
+    assert xy_plane.shape == (3, n_pix**2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -116,7 +116,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     xy_plane = test_ir.generate_xy_plane(n_pix)
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, rots)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
 
     map_3d_dc = np.zeros((n_pix, n_pix, n_pix))
     rand_val = np.random.uniform(low=1, high=2)

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -78,7 +78,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix**2)
+    assert xy_plane.shape == (3, n_pix ** 2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -116,7 +116,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     xy_plane = test_ir.generate_xy_plane(n_pix)
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, rots)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
 
     map_3d_dc = np.zeros((n_pix, n_pix, n_pix))
     rand_val = np.random.uniform(low=1, high=2)

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -44,7 +44,7 @@ def test_ir(n_pix, n_particles, rand_defocus, rand_angle_list):
         "batch_size": n_particles,
         "cs": 2.7,
         "ctf_size": pixels,
-        "kv": 0.1968,
+        "kv": 300,
         "pixel_size": 128,
         "side_len": pixels,
         "value_nyquist": 0.1,

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -96,7 +96,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix ** 2)
+    assert xy_plane.shape == (3, n_pix**2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -134,7 +134,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     xy_plane = test_ir.generate_xy_plane(n_pix)
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, rots)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
 
     map_3d_dc = np.zeros((n_pix, n_pix, n_pix))
     rand_val = np.random.uniform(low=1, high=2)

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -98,7 +98,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix**2)
+    assert xy_plane.shape == (3, n_pix ** 2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -136,7 +136,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     xy_plane = test_ir.generate_xy_plane(n_pix)
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, rots)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
 
     map_3d_dc = np.zeros((n_pix, n_pix, n_pix))
     rand_val = np.random.uniform(low=1, high=2)

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -37,8 +37,8 @@ def rand_defocus(n_particles):
 @pytest.fixture
 def test_ir(n_pix, n_particles):
     """Instantiate IterativeRefinement class for testing."""
-    defocus_list = rand_defocus(n_particles)
-    angle_list = rand_angle_list(n_particles)
+    defocus_list = rand_defocus
+    angle_list = rand_angle_list
     pixels = n_pix()
     ctf_info = {
         "amplitude_contrast": 0.1,
@@ -98,7 +98,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix**2)
+    assert xy_plane.shape == (3, n_pix ** 2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -136,7 +136,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     xy_plane = test_ir.generate_xy_plane(n_pix)
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, rots)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
 
     map_3d_dc = np.zeros((n_pix, n_pix, n_pix))
     rand_val = np.random.uniform(low=1, high=2)

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -98,7 +98,7 @@ def test_grid_SO3_uniform(test_ir, n_particles):
 def test_generate_xy_plane(test_ir, n_pix):
     """Test generation of xy plane."""
     xy_plane = test_ir.generate_xy_plane(n_pix)
-    assert xy_plane.shape == (3, n_pix ** 2)
+    assert xy_plane.shape == (3, n_pix**2)
 
     n_pix_2 = 2
     plane_2 = np.array([[-1, 0, -1, 0], [-1, -1, 0, 0], [0, 0, 0, 0]])
@@ -136,7 +136,7 @@ def test_generate_slices(test_ir, n_particles, n_pix):
     xy_plane = test_ir.generate_xy_plane(n_pix)
     slices, xyz_rotated_planes = test_ir.generate_slices(map_3d, xy_plane, rots)
     assert slices.shape == (n_particles, n_pix, n_pix)
-    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix ** 2)
+    assert xyz_rotated_planes.shape == (n_particles, 3, n_pix**2)
 
     map_3d_dc = np.zeros((n_pix, n_pix, n_pix))
     rand_val = np.random.uniform(low=1, high=2)

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -37,8 +37,8 @@ def rand_defocus(n_particles):
 @pytest.fixture
 def test_ir(n_pix, n_particles):
     """Instantiate IterativeRefinement class for testing."""
-    defocus_list = rand_defocus
-    angle_list = rand_angle_list
+    defocus_list = rand_defocus(n_particles)
+    angle_list = rand_angle_list(n_particles)
     pixels = n_pix
     ctf_info = {
         "amplitude_contrast": 0.1,


### PR DESCRIPTION
Design choice that needs to be discussed!

We propose `self.ctf_info` to instead be a singular dictionary instead of a list of dicts. `ctf_info` would contain CTF config values, and contain an additional key, `ctf_params`, which holds 3 key-value pairs. The keys would be the defocus u, v, angles, and the values would be an ordered list (with each index corresponding to a particle).

```
self.ctf_info = {   
            'amplitude_contrast': 0.1,
            'b_factor': 0.0,
            'batch_size': len(self.particles),  # num samples
            'cs': 2.7,
            'ctf_size': 32,  # n_pix
            'kv': 300,
            'pixel_size': 3.2,
            'side_len': 32,
            'value_nyquist': 0.1,
            'ctf_params' : {   # user would also pass this part in
                'defocus_u' : [...],
                'defocus_v' : [...],
                'defocus_angle' : [...], 
            }
        }
```
   

This follows the required input/output from `linear_simulator.ctf`
https://github.com/compSPI/simSPI/blob/master/simSPI/linear_simulator/ctf.py